### PR TITLE
test_device_brandmodel.yaml merged into test_device.yaml

### DIFF
--- a/ua_parser/user_agent_parser_test.py
+++ b/ua_parser/user_agent_parser_test.py
@@ -53,10 +53,6 @@ class ParseTest(unittest.TestCase):
         self.runDeviceTestsFromYAML(os.path.join(
             TEST_RESOURCES_DIR, 'tests/test_device.yaml'))
 
-    def testStringsDeviceBrandModel(self):
-        self.runDeviceTestsFromYAML(os.path.join(
-            TEST_RESOURCES_DIR, 'tests/test_device_brandmodel.yaml'))
-
     def testMozillaStrings(self):
         self.runUserAgentTestsFromYAML(os.path.join(
             TEST_RESOURCES_DIR, 'test_resources/firefox_user_agent_strings.yaml'))


### PR DESCRIPTION
As of https://github.com/ua-parser/uap-core/pull/10#issuecomment-65376279 the test cases from test_device_brandmodel.yaml are now merged into test_device.yaml.
This requires an adaptation of the tests.