### PR TITLE
Update setup.py to enable pip installs direct from github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup
 from setuptools.command.develop import develop as _develop
 from setuptools.command.sdist import sdist as _sdist
+from setuptools.command.install import install as _install
 
 
 def install_regexes():
@@ -37,6 +38,11 @@ class sdist(_sdist):
         _sdist.run(self)
 
 
+class install(_install):
+    def run(self):
+        install_regexes()
+        _install.run(self)
+
 setup(
     name='ua-parser',
     version='0.4.1',
@@ -50,10 +56,12 @@ setup(
     url='https://github.com/ua-parser/uap-python',
     include_package_data=True,
     package_data={'ua_parser': ['regexes.yaml', 'regexes.json']},
+    setup_requires=['pyyaml'],
     install_requires=['pyyaml'],
     cmdclass={
         'develop': develop,
         'sdist': sdist,
+        'install': install,
     },
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
_Edit: Did a bit more work on this and rewrote the pull request description to be clearer_

I've found that you can't install the uap-python library direct from github using pip or as a dependency for a project installed using setuptools.

There are 2 possible URLs that you can point pip/setup.py at:
* Git repo: `git+https://github.com/ua-parser/uap-python.git@master#egg=ua-parser-0.4.0`
* Tarball: `https://github.com/ua-parser/uap-python/tarball/master#egg=ua-parser-0.4.0`

There appears to be 2 issues:
* The tarball download doesn't include the uap-core submodule, so doesn't include the regexes.yaml
* The setup.py install command doesn't install the regexes.yaml and regexes.json files (unlike the develop and sdist commands)

I can't find a workaround/solution for the tarball download not including the submodule, it seems to be a limitation of the feature that github provides.

For the installation of the regexes files, I updated the setup.py (hence this pull request)

**Test Methodology**
* I ran all the tests within a virtualenv using pip 1.5.6 (although I'm confident it works fine with later versions as well).

* Between each test case I ran `wipeenv` from virtualenvwrapper to remove all installed python modules.

* To check whether the test passed, I ran `python -c 'import ua_parser.user_agent_parser'`, which produces a traceback if the regexes aren't installed correctly.

* For the tests that installed uap-python as a dependency declared in a setup.py, I created a simple project with the following setup.py:
```python
from setuptools import setup

setup(
    name='ua-test',
    version='0.1',
    packages=['ua-test'],
    url='',
    license='',
    author='Chris Bunney',
    author_email='crbunney@users.noreply.github.com',
    description='',
    install_requires=[
        'ua-parser==0.4.0'
    ],
    dependency_links=[
        'INSERT_TEST_URL_HERE'
    ]
)
```

These are the tests cases I tried:
* pip installs:
  * Direct pip install using git URL: `pip install <git_url>`
  * Direct pip install in editable mode using git URL: `pip install -e <git_url>`
  * Direct pip install using tarball URL: `pip install <tarball_url>`
  * Direct pip install in editable mode using tarball URL: `pip install -e <tarball_url>`
* setup.py installs (executed from test project root)
  * setup.py install using git URL: `pip install --process-dependency-links . # (dependency_links=['<git_url>'])`
  * setup.py install in editable mode using git URL: `pip install --process-dependency-links -e . # (dependency_links=['<git_url>'])`
  * setup.py install using tarball URL: `pip install --process-dependency-links . # (dependency_links=['<tarball_url>'])`
  * setup.py install in editable mode using tarball URL: `pip install --process-dependency-links -e . # (dependency_links=['<tarball_url>'])`

**Test Results Using ua-parser/uap-python/master**
git URL: `git+https://github.com/ua-parser/uap-python.git@master#egg=ua-parser-0.4.0`
tarball URL: `https://github.com/ua-parser/uap-python/tarball/master#egg=ua-parser-0.4.0`

Test Case |  Result
---------------|------------
Direct pip install using git URL | FAILED
Direct pip install in editable mode using git URL | FAILED
Direct pip install using tarball URL | FAILED
Direct pip install in editable mode using tarball URL | INVALID COMMAND (included for completeness)
setup.py install using git URL | FAILED
setup.py install in editable mode using git URL | FAILED
setup.py install using tarball URL | FAILED
setup.py install in editable mode using tarball URL | FAILED

**Test Results Using crbunney/uap-python/fix_pip_install_from_source**
git URL: `git+https://github.com/crbunney/uap-python.git@fix_pip_install_from_source#egg=ua-parser-0.4.0`
tarball URL: `https://github.com/crbunney/uap-python/tarball/fix_pip_install_from_source#egg=ua-parser-0.4.0`

Test Case |  Result
---------------|------------
Direct pip install using git URL | PASSED
Direct pip install in editable mode using git URL | PASSED
Direct pip install using tarball URL | FAILED (due to the tarball download not included the uap-core submodule)
Direct pip install in editable mode using tarball URL | INVALID COMMAND (included for completeness)
setup.py install using git URL | PASSED
setup.py install in editable mode using git URL | PASSED
setup.py install using tarball URL | FAILED (due to the tarball download not included the uap-core submodule)
setup.py install in editable mode using tarball URL | FAILED (due to the tarball download not included the uap-core submodule)