### PR TITLE
Update ua-core to 0.4.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include ua_parser/regexes.yaml
+include ua_parser/regexes.json

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class sdist(_sdist):
 
 setup(
     name='ua-parser',
-    version='0.4.0',
+    version='0.4.1',
     description="Python port of Browserscope's user agent parser",
     author='PBS',
     author_email='no-reply@pbs.org',
@@ -53,7 +53,7 @@ setup(
     install_requires=['pyyaml'],
     cmdclass={
         'develop': develop,
-        'sdist':   sdist,
+        'sdist': sdist,
     },
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Version 0.4.0 on PyPI does not bundle the regex files. I pushed 0.4.1 on PyPI and verified it to work properly.