### PR TITLE
Fix install from sdist and bdist_wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.pyc
+*.egg-info/
+.eggs/
+build/
+dist/
+tmp/
+regexes.yaml
+regexes.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.6"
@@ -9,7 +10,8 @@ before_install:
   - cp uap-core/regexes.yaml ua_parser/regexes.yaml
 
 install:
-  - pip install .
+  - pip install pyyaml
+  - pip install -e .
 
 script:
   - python ua_parser/user_agent_parser_test.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include ua_parser/regexes.yaml
+include README.md
 include ua_parser/regexes.json

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,12 @@ test:
 	@#python ua_parser/user_agent_parser_test.py ParseTest.testStringsDeviceBrandModel
 
 clean:
-	@rm ua_parser/user_agent_parser.pyc\
+	@rm -f ua_parser/user_agent_parser.pyc\
 	   ua_parser/regexes.yaml\
 	   ua_parser/regexes.json
 	@rm -rf tmp\
-	   ua_parser.egg-info
+	   ua_parser.egg-info\
+	   dist\
+	   build
 
 .PHONY: all clean

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,23 @@
 from setuptools import setup
 from setuptools.command.develop import develop as _develop
 from setuptools.command.sdist import sdist as _sdist
-from setuptools.command.install import install as _install
 
 
 def install_regexes():
     print('Copying regexes.yaml to package directory...')
     import os
-    import shutil
     cwd = os.path.abspath(os.path.dirname(__file__))
     yaml_src = os.path.join(cwd, 'uap-core', 'regexes.yaml')
     if not os.path.exists(yaml_src):
         raise RuntimeError(
                   'Unable to find regexes.yaml, should be at %r' % yaml_src)
-    yaml_dest = os.path.join(cwd, 'ua_parser', 'regexes.yaml')
-    shutil.copy2(yaml_src, yaml_dest)
 
     print('Converting regexes.yaml to regexes.json...')
     import json
     import yaml
-    json_dest = yaml_dest.replace('.yaml', '.json')
-    regexes = yaml.safe_load(open(yaml_dest))
+    json_dest = os.path.join(cwd, 'ua_parser', 'regexes.json')
+    with open(yaml_src, 'rb') as fp:
+        regexes = yaml.safe_load(fp)
     with open(json_dest, "w") as f:
         json.dump(regexes, f)
 
@@ -38,11 +35,6 @@ class sdist(_sdist):
         _sdist.run(self)
 
 
-class install(_install):
-    def run(self):
-        install_regexes()
-        _install.run(self)
-
 setup(
     name='ua-parser',
     version='0.5.0',
@@ -55,13 +47,12 @@ setup(
     zip_safe=False,
     url='https://github.com/ua-parser/uap-python',
     include_package_data=True,
-    package_data={'ua_parser': ['regexes.yaml', 'regexes.json']},
+    package_data={'ua_parser': ['regexes.json']},
     setup_requires=['pyyaml'],
-    install_requires=['pyyaml'],
+    install_requires=[],
     cmdclass={
         'develop': develop,
         'sdist': sdist,
-        'install': install,
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -434,20 +434,19 @@ regexes = None
 if not UA_PARSER_YAML:
     try:
         from pkg_resources import resource_filename
-        yamlPath = resource_filename(__name__, 'regexes.yaml')
         json_path = resource_filename(__name__, 'regexes.json')
     except ImportError:
-        yamlPath = os.path.join(ROOT_DIR, 'regexes.yaml')
         json_path = os.path.join(ROOT_DIR, 'regexes.json')
 else:
+    # This will raise an ImportError if missing, obviously since it's no
+    # longer a requirement
     import yaml
 
     with open(UA_PARSER_YAML) as yamlFile:
         regexes = yaml.safe_load(yamlFile)
 
 
-# If UA_PARSER_YAML is not specified, load regexes from regexes.json before
-# falling back to yaml format
+# If UA_PARSER_YAML is not specified, load regexes from regexes.json
 if regexes is None:
     try:
         import json
@@ -455,10 +454,7 @@ if regexes is None:
         with open(json_path) as fp:
             regexes = json.load(fp)
     except IOError:
-        import yaml
-
-        with open(yamlPath) as fp:
-            regexes = yaml.safe_load(fp)
+        pass
 
 
 USER_AGENT_PARSERS = []

--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -448,13 +448,10 @@ else:
 
 # If UA_PARSER_YAML is not specified, load regexes from regexes.json
 if regexes is None:
-    try:
-        import json
+    import json
 
-        with open(json_path) as fp:
-            regexes = json.load(fp)
-    except IOError:
-        pass
+    with open(json_path) as fp:
+        regexes = json.load(fp)
 
 
 USER_AGENT_PARSERS = []


### PR DESCRIPTION
Ok, so this one fixes up lots of things. (not sure how this was working before tbh)

* `python setup.py install` didn't work on on `sdist` artifact because it was attempting to run `install_regexes` which don't exist. They're expected to already be in the bundled artifact. This would affect installing `ua-parser` from PyPI for example since `install` gets run during `pip install`.
* After an `sdist` run, we don't need the `yaml` file anymore, since we have "compiled" into a json file. Meaning, we can leave the `yaml` file behind, and only package up the `json` file. This also means that we can remove `pyyaml` as a runtime dependency, and only keep it as a setup dependency.
* Add support for compiling a wheel with `bdist_wheel`.

So here's the blobs of data that I tested with:

Output from compiling the sdist and wheel:
```
$ python setup.py sdist bdist_wheel
running sdist
Copying regexes.yaml to package directory...
Converting regexes.yaml to regexes.json...
running egg_info
creating ua_parser.egg-info
writing ua_parser.egg-info/PKG-INFO
writing top-level names to ua_parser.egg-info/top_level.txt
writing dependency_links to ua_parser.egg-info/dependency_links.txt
writing pbr to ua_parser.egg-info/pbr.json
writing manifest file 'ua_parser.egg-info/SOURCES.txt'
reading manifest file 'ua_parser.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'ua_parser.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating ua-parser-0.5.0
creating ua-parser-0.5.0/ua_parser
creating ua-parser-0.5.0/ua_parser.egg-info
making hard links in ua-parser-0.5.0...
hard linking MANIFEST.in -> ua-parser-0.5.0
hard linking README.md -> ua-parser-0.5.0
hard linking setup.cfg -> ua-parser-0.5.0
hard linking setup.py -> ua-parser-0.5.0
hard linking ./ua_parser/__init__.py -> ua-parser-0.5.0/./ua_parser
hard linking ./ua_parser/user_agent_parser.py -> ua-parser-0.5.0/./ua_parser
hard linking ./ua_parser/user_agent_parser_test.py -> ua-parser-0.5.0/./ua_parser
hard linking ua_parser/regexes.json -> ua-parser-0.5.0/ua_parser
hard linking ua_parser.egg-info/PKG-INFO -> ua-parser-0.5.0/ua_parser.egg-info
hard linking ua_parser.egg-info/SOURCES.txt -> ua-parser-0.5.0/ua_parser.egg-info
hard linking ua_parser.egg-info/dependency_links.txt -> ua-parser-0.5.0/ua_parser.egg-info
hard linking ua_parser.egg-info/not-zip-safe -> ua-parser-0.5.0/ua_parser.egg-info
hard linking ua_parser.egg-info/pbr.json -> ua-parser-0.5.0/ua_parser.egg-info
hard linking ua_parser.egg-info/top_level.txt -> ua-parser-0.5.0/ua_parser.egg-info
copying setup.cfg -> ua-parser-0.5.0
Writing ua-parser-0.5.0/setup.cfg
creating dist
Creating tar archive
removing 'ua-parser-0.5.0' (and everything under it)
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/ua_parser
copying ./ua_parser/__init__.py -> build/lib/ua_parser
copying ./ua_parser/user_agent_parser.py -> build/lib/ua_parser
copying ./ua_parser/user_agent_parser_test.py -> build/lib/ua_parser
copying ./ua_parser/regexes.json -> build/lib/ua_parser
installing to build/bdist.macosx-10.11-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.11-x86_64
creating build/bdist.macosx-10.11-x86_64/wheel
creating build/bdist.macosx-10.11-x86_64/wheel/ua_parser
copying build/lib/ua_parser/__init__.py -> build/bdist.macosx-10.11-x86_64/wheel/ua_parser
copying build/lib/ua_parser/regexes.json -> build/bdist.macosx-10.11-x86_64/wheel/ua_parser
copying build/lib/ua_parser/user_agent_parser.py -> build/bdist.macosx-10.11-x86_64/wheel/ua_parser
copying build/lib/ua_parser/user_agent_parser_test.py -> build/bdist.macosx-10.11-x86_64/wheel/ua_parser
running install_egg_info
Copying ua_parser.egg-info to build/bdist.macosx-10.11-x86_64/wheel/ua_parser-0.5.0-py2.7.egg-info
running install_scripts
creating build/bdist.macosx-10.11-x86_64/wheel/ua_parser-0.5.0.dist-info/WHEEL
```

Our dist output has both the `tar.gz` and `whl` files.
```
$ ls dist
ua-parser-0.5.0.tar.gz               ua_parser-0.5.0-py2.py3-none-any.whl
```

Listing contents of sdist shows the `regexes.json` packaged inside:
```
$ tar ztvf dist/*.tar.gz
drwxr-xr-x  0 matt   staff       0 Oct 11 04:02 ua-parser-0.5.0/
-rw-r--r--  0 matt   staff      49 Oct 11 03:50 ua-parser-0.5.0/MANIFEST.in
-rw-r--r--  0 matt   staff    1142 Oct 11 04:02 ua-parser-0.5.0/PKG-INFO
-rw-r--r--  0 matt   staff    2684 Oct 11 02:33 ua-parser-0.5.0/README.md
-rw-r--r--  0 matt   staff      88 Oct 11 04:02 ua-parser-0.5.0/setup.cfg
-rw-r--r--  0 matt   staff    2426 Oct 11 03:49 ua-parser-0.5.0/setup.py
drwxr-xr-x  0 matt   staff       0 Oct 11 04:02 ua-parser-0.5.0/ua_parser/
-rw-r--r--  0 matt   staff      20 Oct 11 02:33 ua-parser-0.5.0/ua_parser/__init__.py
-rw-r--r--  0 matt   staff  117000 Oct 11 04:02 ua-parser-0.5.0/ua_parser/regexes.json
-rw-r--r--  0 matt   staff   18685 Oct 11 03:38 ua-parser-0.5.0/ua_parser/user_agent_parser.py
-rw-r--r--  0 matt   staff    9685 Oct 11 02:44 ua-parser-0.5.0/ua_parser/user_agent_parser_test.py
drwxr-xr-x  0 matt   staff       0 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/
-rw-r--r--  0 matt   staff       1 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/dependency_links.txt
-rw-r--r--  0 matt   staff       1 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/not-zip-safe
-rw-r--r--  0 matt   staff      47 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/pbr.json
-rw-r--r--  0 matt   staff    1142 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/PKG-INFO
-rw-r--r--  0 matt   staff     350 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/SOURCES.txt
-rw-r--r--  0 matt   staff      10 Oct 11 04:02 ua-parser-0.5.0/ua_parser.egg-info/top_level.txt
```

And also exists inside the `whl`.
```
$ tar ztvf dist/*.whl
-rwxrwxrwx  0 0      0          20 Oct 11 02:33 ua_parser/__init__.py
-rwxrwxrwx  0 0      0      117000 Oct 11 04:02 ua_parser/regexes.json
-rwxrwxrwx  0 0      0       18685 Oct 11 03:38 ua_parser/user_agent_parser.py
-rwxrwxrwx  0 0      0        9685 Oct 11 02:44 ua_parser/user_agent_parser_test.py
-rwxrwxrwx  0 0      0          10 Oct 11 04:02 ua_parser-0.5.0.dist-info/DESCRIPTION.rst
-rwxrwxrwx  0 0      0        1172 Oct 11 04:02 ua_parser-0.5.0.dist-info/metadata.json
-rwxrwxrwx  0 0      0          47 Oct 11 04:02 ua_parser-0.5.0.dist-info/pbr.json
-rwxrwxrwx  0 0      0          10 Oct 11 04:02 ua_parser-0.5.0.dist-info/top_level.txt
-rwxrwxrwx  0 0      0         110 Oct 11 04:02 ua_parser-0.5.0.dist-info/WHEEL
-rwxrwxrwx  0 0      0        1132 Oct 11 04:02 ua_parser-0.5.0.dist-info/METADATA
-rwxrwxrwx  0 0      0         936 Oct 11 04:02 ua_parser-0.5.0.dist-info/RECORD
```

Now, if we take the `dist/` folder, we can install the files individually with `pip` without any issues. ala `pip install dist/ua-parser-0.5.0.tar.gz` or `pip install dist/ua_parser-0.5.0-py2.py3-none-any.whl`