### PR TITLE
Adding a few words about how to install via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ A python implementation of the UA Parser (https://github.com/ua-parser, formerly
 
 ##Installing
 
+### Install via pip
+First, check that you've got the correct dependencies. For example, on Ubuntu:
+```
+$ apt-get install libyaml libyaml-dev python-dev
+```
+Then, just run:
+```
+$ pip install pyyaml ua-parser user-agents
+```
+
+### Manual install
 In the top-level directory run:
 ```
 $ make
@@ -16,7 +27,7 @@ $ make
 
 ### retrieve data on a user-agent string
 ```
->>> import user_agent_parser
+>>> from ua_parser import user_agent_parser
 >>> import pprint
 >>> pp = pprint.PrettyPrinter(indent=4)
 >>> ua_string = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.104 Safari/537.36'
@@ -39,7 +50,7 @@ $ make
 ### extract browser data from user-agent string
 
 ```
->>> import user_agent_parser
+>>> from ua_parser import user_agent_parser
 >>> import pprint
 >>> pp = pprint.PrettyPrinter(indent=4)
 >>> ua_string = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.104 Safari/537.36'
@@ -54,7 +65,7 @@ $ make
 ### extract OS information from user-agent string
 
 ```
->>> import user_agent_parser
+>>> from ua_parser import user_agent_parser
 >>> import pprint
 >>> pp = pprint.PrettyPrinter(indent=4)
 >>> ua_string = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.104 Safari/537.36'
@@ -71,7 +82,7 @@ $ make
 
 
 ```
->>> import user_agent_parser
+>>> from ua_parser import user_agent_parser
 >>> import pprint
 >>> pp = pprint.PrettyPrinter(indent=4)
 >>> ua_string = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.104 Safari/537.36'

--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ A python implementation of the UA Parser (https://github.com/ua-parser, formerly
 ##Installing
 
 ### Install via pip
-First, check that you've got the correct dependencies. For example, on Ubuntu:
+Just run:
 ```
-$ apt-get install libyaml libyaml-dev python-dev
-```
-Then, just run:
-```
-$ pip install pyyaml ua-parser user-agents
+$ pip install ua-parse
 ```
 
 ### Manual install


### PR DESCRIPTION
I'm adding a few words about how to install the package from pip.

I'm also fixing the imports in the examples; at least when installed from pip, `import user_agent_parser` won't work, you will need something like `from ua_parser import user_agent_parser`.