### PR TITLE
Partial refactor to support substitutions in replacement strings as per spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ class build_regexes(Command):
                 fp.write(force_bytes('        %r,\n' % device_parser.get('family_replacement')))
                 fp.write(force_bytes('        %r,\n' % device_parser.get('v1_replacement')))
                 fp.write(force_bytes('        %r,\n' % device_parser.get('v2_replacement')))
+                fp.write(force_bytes('        %r,\n' % device_parser.get('v3_replacement')))
                 fp.write(b'    ),\n')
             fp.write(b']\n')
             fp.write(b'\n')


### PR DESCRIPTION
This is a partial refactor to bring uap-python closer to the specification in uap-core.   

It supports regular expression backreferences for replacements for all parsers - uap-core has started to use these for UAParser and OSParser instances, and only DeviceParser currently supports. (note: this was true of the regexes I imported at the time - it appears uap-core had done some cleanup and this is somewhat better now)

I believe the spec (https://github.com/ua-parser/uap-core/blob/master/docs/specification.md)
does indicate that all matches from $1 to $9 should be honored for every
replacement.

> Each parser contains a list of regular-expressions which are named regex. For each regex replacements specific to the parser can be named to attribute or change information. A replacement may require a match from the regular-expression which is extracted by an expression enclosed in normal brackets "()". Each match can be addressed with $1 to $9 and used in a parser specific replacement.

It additionally allows for a v3 replacement for UserAgent.

Refactored the class hierarchy so that it's sort of DRY, and moved MultiReplace to a module level function because it doesn't use self.

Looking forward to any feedback!