### PR TITLE
Update from uap-core 0.6.7 to 0.6.9

### DIFF
--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -135,6 +135,7 @@ class OSParser(object):
 
         return os, os_v1, os_v2, os_v3, os_v4
 
+
 def MultiReplace(string, match):
     def _repl(m):
         index = int(m.group(1)) - 1
@@ -148,6 +149,7 @@ def MultiReplace(string, match):
     if _string == '':
         return None
     return _string
+
 
 class DeviceParser(object):
     def __init__(self, pattern, regex_flag=None, device_replacement=None, brand_replacement=None,


### PR DESCRIPTION
Builds off #70.  The changes required to make tests work seem to mainly be in parts of the parser previously un-exercised by the test suite - the 3 test failures I found were two issues of empty string where None was required, and one where $2 and $3 were poking through in the OS detection for "MacOutlook/16.12.0.180401 (Intelx64 Mac OS X Version 10.12.6 (build 16G29))"

AssertionError: UA: MacOutlook/16.12.0.180401 (Intelx64 Mac OS X Version 10.12.6 (build 16G29))
 expected<Mac OS X 10 12 6 None> != actual<Mac OS X 10 $2 $3 None>
so I repurposed the logic for dealing with those expressions in DeviceParser for OSParser as well.

after hacking this up I realized it's somewhat similar to PR #60; there's probably some merit in rebasing that PR and seeing if it caught anything I missed here, to help make future uap-core updates smoother; but that can be done as a followup