### PR TITLE
added py37 and py38 to tox.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, docs, py27-flake8, py36-flake8
+envlist = py27, py36, py37, py38, docs, py27-flake8, py36-flake8
 
 [testenv]
 deps =
@@ -9,6 +9,7 @@ commands =
     python ua_parser/user_agent_parser_test.py
 
 [testenv:docs]
+basepython = python2.7
 deps = docutils
        Pygments
 commands =


### PR DESCRIPTION
* added python 3.7 to tox envs.
* added python 3.8 to tox envs.
* marked 3.7 and 3.8 as officially supported.
* [extra] added explicit basepython 2.7 to `docs` as running it locally complained that there was no base python.