### PR TITLE
[Security] Bump uap-core to 0.8.0 to avoid DoS

### DIFF
--- a/ua_parser/user_agent_parser_test.py
+++ b/ua_parser/user_agent_parser_test.py
@@ -85,7 +85,7 @@ class ParseTest(unittest.TestCase):
     def testParseAll(self):
         user_agent_string = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; fr; rv:1.9.1.5) Gecko/20091102 Firefox/3.5.5,gzip(gfe),gzip(gfe)"
         expected = {
-            "device": {"family": "Other", "brand": None, "model": None},
+            "device": {"family": "Mac", "brand": "Apple", "model": "Mac"},
             "os": {
                 "family": "Mac OS X",
                 "major": "10",


### PR DESCRIPTION
A security advisory for uap-core was published at
https://github.com/ua-parser/uap-core/security/advisories/GHSA-cmcx-xhr8-3w9p

Denial of Service in uap-core <=0.7.2 when processing crafted User-Agent strings

This fixes the 4 regular expressions vulnerable to Regular Expression
Denial of Service (REDoS).

Please also publish a security advisory so the downstream python packages get notifications.