### PR TITLE
Add note that the convenience parsers are not cached to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,16 @@ Extract browser data from user-agent string
     >>> pp.pprint(parsed_string)
     {'family': 'Chrome', 'major': '41', 'minor': '0', 'patch': '2272'}
 
+..
+
+    ⚠️The convenience parsers (``ParseUserAgent``, ``ParseOs``, and
+    ``ParseDevice``) currently have no caching, which can result in
+    degraded performances when parsing large amounts of identical
+    user-agents (which might occur for real-world datasets).
+
+    In that case, prefer using ``Parse`` and extracting the
+    sub-component you need from the resulting dictionary.
+
 Extract OS information from user-agent string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
An even better solution would be to cache them, but *just* caching
them seems redundant with the existing cache, so things would need to
be rethought.

Fixes #97