### PR TITLE
Formally deprecate functions which were initially imported deprecated.

### DIFF
--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 import os
 import re
+import warnings
 
 __author__ = "Lindsey Simon <elsigh@gmail.com>"
 
@@ -369,6 +370,9 @@ def ParseWithJSOverrides(
     js_user_agent_v3=None,
 ):
     """backwards compatible. use one of the other Parse methods instead!"""
+    warnings.warn(
+        "Use Parse (or a specialised parser)", DeprecationWarning, stacklevel=2
+    )
 
     # Override via JS properties.
     if js_user_agent_family is not None and js_user_agent_family != "":
@@ -405,6 +409,7 @@ def ParseWithJSOverrides(
 
 def Pretty(family, v1=None, v2=None, v3=None):
     """backwards compatible. use PrettyUserAgent instead!"""
+    warnings.warn("Use PrettyUserAgent", DeprecationWarning, stacklevel=2)
     if v3:
         if v3[0].isdigit():
             return "%s %s.%s.%s" % (family, v1, v2, v3)

--- a/ua_parser/user_agent_parser_test.py
+++ b/ua_parser/user_agent_parser_test.py
@@ -30,6 +30,7 @@ __author__ = "slamm@google.com (Stephen Lamm)"
 import os
 import re
 import unittest
+import warnings
 import yaml
 
 try:
@@ -284,6 +285,35 @@ class GetFiltersTest(unittest.TestCase):
         self.assertEqual(
             {"js_user_agent_string": "bar", "js_user_agent_family": "foo"}, filters
         )
+
+
+class TestDeprecationWarnings(unittest.TestCase):
+    def setUp(self):
+        """In Python 2.7, catch_warnings apparently does not do anything if
+        the warning category is not active, whereas in 3(.6 and up) it
+        seems to work out of the box.
+        """
+        super(TestDeprecationWarnings, self).setUp()
+        warnings.simplefilter("default", DeprecationWarning)
+
+    def tearDown(self):
+        # not ideal as it discards all other warnings updates from the
+        # process, should really copy the contents of
+        # `warnings.filters`, then reset-it.
+        warnings.resetwarnings()
+        super(TestDeprecationWarnings, self).tearDown()
+
+    def test_parser_deprecation(self):
+        with warnings.catch_warnings(record=True) as ws:
+            user_agent_parser.ParseWithJSOverrides("")
+        self.assertEqual(len(ws), 1)
+        self.assertEqual(ws[0].category, DeprecationWarning)
+
+    def test_printer_deprecation(self):
+        with warnings.catch_warnings(record=True) as ws:
+            user_agent_parser.Pretty("")
+        self.assertEqual(len(ws), 1)
+        self.assertEqual(ws[0].category, DeprecationWarning)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Probably going to remove them, especially since `ParseWithJSOverrides`
was originally called `Parse`, and that got switcheroo'd in one of the
early commit, with the original `ParseAll` renamed `Parse`. Therefore
the backwards compatibility was not really a thing per-se.