### PR TITLE
Migrate to pytest as test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       run: |
         python -mpip install --upgrade pip
         python -mpip install -r requirements_dev.txt
-    - name: tests
-      run: |
-        python setup.py develop
-        env time -v python ./ua_parser/user_agent_parser_test.py
-    - name: doctests
+    - name: install package in environment
+      run: python setup.py develop
+    - name: run tests
+      run: pytest
+    - name: run doctests
       # pprint formatting was changed a lot in 3.5
       if: ${{ matrix.python-version != '2.7' }}
       run: python -mdoctest README.rst

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
+pytest
 pyyaml~=5.4.0
 tox==3.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,12 @@ skipsdist = True
 usedevelop = True
 deps = -rrequirements_dev.txt
 commands =
-    python ua_parser/user_agent_parser_test.py
+    pytest {posargs}
     python -mdoctest README.rst
 
 [testenv:py27]
 # no doctesting in 2.7 because of formatting divergences
-commands = python ua_parser/user_agent_parser_test.py
+commands = pytest {posargs}
 
 [testenv:docs]
 skip_install = True


### PR DESCRIPTION
- it works with the existing
- it's easy to select individual tests, and to split the test
  suite, "unittest discover" would as well but is more verbose and
  doesn't work in 2.7 (unittest2 is necessary)
- it has a really nice reporting
- I want to use pytest's nice everything