### PR TITLE
Don't generate unnecessary lines in _regexes.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,14 @@ class build_regexes(Command):
                 return text
             return text.encode("utf8")
 
+        def write_params(fields):
+            # strip trailing None values
+            while len(fields) > 1 and fields[-1] is None:
+                fields.pop()
+
+            for field in fields:
+                fp.write(("        %r,\n" % field).encode("utf-8"))
+
         import yaml
 
         py_dest = os.path.join(self.build_lib, "ua_parser", "_regexes.py")
@@ -103,40 +111,44 @@ class build_regexes(Command):
             fp.write(b"    UserAgentParser, DeviceParser, OSParser,\n")
             fp.write(b")\n")
             fp.write(b"\n")
-            fp.write(b"__all__ = (\n")
-            fp.write(b"    'USER_AGENT_PARSERS', 'DEVICE_PARSERS', 'OS_PARSERS',\n")
-            fp.write(b")\n")
+            fp.write(b"__all__ = ('USER_AGENT_PARSERS', 'DEVICE_PARSERS', 'OS_PARSERS')\n")
             fp.write(b"\n")
             fp.write(b"USER_AGENT_PARSERS = [\n")
             for device_parser in regexes["user_agent_parsers"]:
                 fp.write(b"    UserAgentParser(\n")
-                fp.write(force_bytes("        %r,\n" % device_parser["regex"]))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("family_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("v1_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("v2_replacement")))
+                write_params([
+                    device_parser["regex"],
+                    device_parser.get("family_replacement"),
+                    device_parser.get("v1_replacement"),
+                    device_parser.get("v2_replacement"),
+                ])
                 fp.write(b"    ),\n")
             fp.write(b"]\n")
             fp.write(b"\n")
             fp.write(b"DEVICE_PARSERS = [\n")
             for device_parser in regexes["device_parsers"]:
                 fp.write(b"    DeviceParser(\n")
-                fp.write(force_bytes("        %r,\n" % device_parser["regex"]))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("regex_flag")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("device_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("brand_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("model_replacement")))
+                write_params([
+                    device_parser["regex"],
+                    device_parser.get("regex_flag"),
+                    device_parser.get("device_replacement"),
+                    device_parser.get("brand_replacement"),
+                    device_parser.get("model_replacement"),
+                ])
                 fp.write(b"    ),\n")
             fp.write(b"]\n")
             fp.write(b"\n")
             fp.write(b"OS_PARSERS = [\n")
             for device_parser in regexes["os_parsers"]:
                 fp.write(b"    OSParser(\n")
-                fp.write(force_bytes("        %r,\n" % device_parser["regex"]))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("os_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("os_v1_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("os_v2_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("os_v3_replacement")))
-                fp.write(force_bytes("        %r,\n" % device_parser.get("os_v4_replacement")))
+                write_params([
+                    device_parser["regex"],
+                    device_parser.get("os_replacement"),
+                    device_parser.get("os_v1_replacement"),
+                    device_parser.get("os_v2_replacement"),
+                    device_parser.get("os_v3_replacement"),
+                    device_parser.get("os_v4_replacement"),
+                ])
                 fp.write(b"    ),\n")
             fp.write(b"]\n")
             # fmt: on


### PR DESCRIPTION
The regex builder would generate one ctor parameter for each parser
field. However a *significant* number of entries have less than the
full complement of fields specified, and the "late" fields are
generally the missig one.

Strip the list of fields before writing out the constructors,
switching to kwargs doesn't seem like it would be a huge gain however
this reduces the size of _regexes.py by about 1400 lines as of
0.15 (7860 lines to 6464). This also seems to result in slight gains
in memory footprint following the import of the library.