### PR TITLE
Deprecate js override bits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: install package in environment
       run: python setup.py develop
     - name: run tests
-      run: pytest -v
+      run: pytest -v -Werror
     - name: run doctests
       # pprint formatting was changed a lot in 3.5
       if: ${{ matrix.python-version != '2.7' }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, docs, flake8, black
+envlist = py27, py36, py37, py38, py39, py310, pypy3.8, docs, flake8, black
 skipsdist = True
 
 [testenv]
 usedevelop = True
 deps = -rrequirements_dev.txt
 commands =
-    pytest {posargs}
+    pytest -Werror {posargs}
     python -mdoctest README.rst
 
 [testenv:py27]

--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -244,7 +244,6 @@ def Parse(user_agent_string, **jsParseBits):
     """Parse all the things
     Args:
       user_agent_string: the full user agent string
-      jsParseBits: javascript override bits
     Returns:
       A dictionary containing all parsed bits
     """
@@ -268,7 +267,6 @@ def ParseUserAgent(user_agent_string, **jsParseBits):
     """Parses the user-agent string for user agent (browser) info.
     Args:
       user_agent_string: The full user-agent string.
-      jsParseBits: javascript override bits.
     Returns:
       A dictionary containing parsed bits.
     """
@@ -276,6 +274,12 @@ def ParseUserAgent(user_agent_string, **jsParseBits):
 
 
 def _ParseUserAgent(user_agent_string, jsParseBits):
+    if jsParseBits:
+        warnings.warn(
+            "javascript overrides are deprecated and will be removed next release",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     if (
         "js_user_agent_family" in jsParseBits
         and jsParseBits["js_user_agent_family"] != ""
@@ -318,7 +322,6 @@ def ParseOS(user_agent_string, **jsParseBits):
     """Parses the user-agent string for operating system info
     Args:
       user_agent_string: The full user-agent string.
-      jsParseBits: javascript override bits.
     Returns:
       A dictionary containing parsed bits.
     """
@@ -326,6 +329,12 @@ def ParseOS(user_agent_string, **jsParseBits):
 
 
 def _ParseOS(user_agent_string, jsParseBits):
+    if jsParseBits:
+        warnings.warn(
+            "javascript overrides are deprecated and will be removed next release",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     for osParser in OS_PARSERS:
         os, os_v1, os_v2, os_v3, os_v4 = osParser.Parse(user_agent_string)
         if os:
@@ -344,7 +353,6 @@ def ParseDevice(user_agent_string, **jsParseBits):
     """Parses the user-agent string for device info.
     Args:
         user_agent_string: The full user-agent string.
-        ua_family: The parsed user agent family name.
     Returns:
         A dictionary containing parsed bits.
     """
@@ -352,6 +360,12 @@ def ParseDevice(user_agent_string, **jsParseBits):
 
 
 def _ParseDevice(user_agent_string, jsParseBits):
+    if jsParseBits:
+        warnings.warn(
+            "javascript overrides are deprecated and will be removed next release",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     for deviceParser in DEVICE_PARSERS:
         device, brand, model = deviceParser.Parse(user_agent_string)
         if device:


### PR DESCRIPTION
They were a feature for testing whose need was removed in 2015 (ua-parser/uap-core#58). They are *entirely* unnecessary, it is possible a user somewhere is leveraging them for some reason.

So remove the override bits from the docstrings, and have them trigger a `DeprecationWarning`.

Also:

- add tests that they do trigger
- remove support for them from the yaml testing functions
- update the pytest invocations to raise on all warnings
- while at it remove the apparently dead makePGTSComparisonYAML test utility method (?)
- and add pypy to the envlist