### PR TITLE
Add type assertion to the cache lookup

### DIFF
--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 import os
 import re
+import sys
 import warnings
 
 __author__ = "Lindsey Simon <elsigh@gmail.com>"
@@ -218,8 +219,15 @@ class DeviceParser(object):
 MAX_CACHE_SIZE = 200
 _PARSE_CACHE = {}
 
+_UA_TYPES = str
+if sys.version_info < (3,):
+    _UA_TYPES = (str, unicode)
+
 
 def _lookup(ua, args):
+    if not isinstance(ua, _UA_TYPES):
+        raise TypeError("Expected user agent to be a string, got %r" % ua)
+
     key = (ua, tuple(sorted(args.items())))
     entry = _PARSE_CACHE.get(key)
     if entry is not None:

--- a/ua_parser/user_agent_parser_test.py
+++ b/ua_parser/user_agent_parser_test.py
@@ -29,6 +29,7 @@ import logging
 import os
 import platform
 import re
+import sys
 import unittest
 import warnings
 import yaml
@@ -299,6 +300,27 @@ class TestDeprecationWarnings(unittest.TestCase):
             self.assertEqual(len(ws), count)
             for w in ws:
                 self.assertEqual(w.category, DeprecationWarning)
+
+
+class ErrTest(unittest.TestCase):
+    @unittest.skipIf(
+        sys.version_info < (3,), "bytes and str are not differentiated in P2"
+    )
+    def test_bytes(self):
+        with self.assertRaises(TypeError):
+            user_agent_parser.Parse(b"")
+
+    def test_int(self):
+        with self.assertRaises(TypeError):
+            user_agent_parser.Parse(0)
+
+    def test_list(self):
+        with self.assertRaises(TypeError):
+            user_agent_parser.Parse([])
+
+    def test_tuple(self):
+        with self.assertRaises(TypeError):
+            user_agent_parser.Parse(())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently if an incorrect type is passed in, it'll raise an error that's anything but clear, either failing in the cache lookup or in the regex application.

Instead, make the error clear by checking upfront.

Closes #122