### PR TITLE
Relax pyyaml versioning during building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,37 @@ jobs:
     - name: black
       run: black --check --diff --color --quiet .
 
+  compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha - 3.11", "pypy-3.8"]
+        pyyaml-version: ["5.1.*", "5.4.*", "6.0.*", "6.*"]
+        exclude:
+          - python-version: 2.7
+            pyyaml-version: 6.0.*
+          - python-version: 2.7
+            pyyaml-version: 6.*
+
+    steps:
+    - name: Checkout working copy
+      uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependency
+      run: |
+        python -mpip install --upgrade pip
+        python -mpip install pyyaml==${{ matrix.pyyaml-version }}
+    - name: Build regexes.py
+      run: python setup.py build_regexes -i
+    - name: Check results
+      run: |
+        # check that _regexes exists, and .eggs does not (== setuptools used our dependency)
+        test -e ua_parser/_regexes.py -a ! -e .eggs
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ setup(
     zip_safe=False,
     url="https://github.com/ua-parser/uap-python",
     include_package_data=True,
-    setup_requires=["pyyaml ~= 5.4.0"],
+    setup_requires=["pyyaml"],
     install_requires=[],
     cmdclass=cmdclass,
     classifiers=[


### PR DESCRIPTION
e27d50d8f4d626f35986eafbfde9bf9ad9cb4cc4 moved the yaml dependency from runtime to dev and updated the version from 5.1 to 5.4 (not 6.0 as that dropped Python 2.7 compatibility), but that turns out to cause issues for people who can't / won't download pyyaml on the fly and require building to work with preinstalled packages, as building regexes now refuses to work with a locally available 6.0.

Remove version bound on pyyaml (though a `>=` bound might also have worked), but add a bunch of tests to ensure the regexes build on all supported versions of Python, and pyyaml (also reinstate 5.1 for that purpose only).

Fixes #121