### PR TITLE
Use range spec for 3.11 in the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha.7", "pypy-3.8"]
+        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha - 3.11", "pypy-3.8"]
 
     steps:
     - name: Checkout working copy


### PR DESCRIPTION
This should allow always testing against the latest 3.11 at the time.