### PR TITLE
Fix non-in-place building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,11 +92,15 @@ class build_regexes(Command):
 
         import yaml
 
-        py_dest = os.path.join(self.build_lib, "ua_parser", "_regexes.py")
-
         log.info("compiling regexes.yaml -> _regexes.py")
         with open(yaml_src, "rb") as fp:
             regexes = yaml.safe_load(fp)
+
+        lib_dest = os.path.join(self.build_lib, "ua_parser")
+        if not os.path.exists(lib_dest):
+            os.makedirs(lib_dest)
+
+        py_dest = os.path.join(lib_dest, "_regexes.py")
         with open(py_dest, "wb") as fp:
             # fmt: off
             fp.write(b"# -*- coding: utf-8 -*-\n")


### PR DESCRIPTION
It's unclear when that stopped (or possibly whether it's ever worked), but "regular" commands which don't build in-place (e.g. a simple `setup.py build`) have not worked in a while, because the overrides on tasks trigger `build_regexes` before the task itself (to say nothing of invoking `build_regexes` directly).

As a result, the build_dir does not exist yet unless there's an old build_dir remaining for some reason, and trying to create the file crashes.

Ensure the build dir exists before trying to write `_regexes.py`. There's a minor TOCTOU in order to handle Python 2's `os.makedirs`, as it doesn't have `exist_ok`.