### PR TITLE
Relax pyyaml dev-dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       run: |
         python -mpip install --upgrade pip
         # if binary wheels are not available for the current package install libyaml
+        # NB: cyaml is outright broken on pypy so exclude that
         if ! ${{matrix.python-version == 'pypy-3.8'}}; then
             if ! pip download --only-binary pyyaml -rrequirements_dev.txt > /dev/null 2>&1; then
                 sudo apt install libyaml-dev

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 pytest
-pyyaml~=5.4.0
+pyyaml
 tox==3.9.0


### PR DESCRIPTION
Followup to #125 as it seems unnecessary to keep 3.10 on an outdated non-binary-wheel version. Especially since it's just for parsing test data.

Allow the test suite to use whatever the latest supported pyyaml is for it. Also install libyaml for pypy.