### PR TITLE
Revert cache FIFO replacement policy to reset/clear

### DIFF
--- a/ua_parser/user_agent_parser.py
+++ b/ua_parser/user_agent_parser.py
@@ -234,7 +234,7 @@ def _lookup(ua, args):
         return entry
 
     if len(_PARSE_CACHE) >= MAX_CACHE_SIZE:
-        _PARSE_CACHE.pop(next(iter(_PARSE_CACHE)))
+        _PARSE_CACHE.clear()
 
     v = _PARSE_CACHE[key] = {"string": ua}
     return v


### PR DESCRIPTION
Amongst other changes, #113 switched the cache to a FIFO inspired by
the standard library's re module, however it didn't really take
concurrency in account, so didn't really consider: that double-pops
are possible (probably why the stdlib ignores a bunch of errors),
which can cause KeyError during lookup (as two workers try to clear
the first key, one succeeds, and the other doesn't find the key and
fails).

It also has a few other less major issues:

- double-inserts are possible, which can cause the cache to exceed set
  capacity permanently by the number of concurrent workers
- the stdlib's method only works properly with Python 3.6's naturally
  ordered `dict`, but I'd rather not drop 2.7 compatibility from 0.x
  unless there are very good causes to as, despite 2.7 having been
  EOL'd in 2020, it still accounts for more downloads than 3.10
  (according to pypistats)

Using an ordered dict would solve (3), and allow using an LRU rather
than a FIFO, but it would not actually prevent double-pops or
double-inserts, that would require a proper lock on lookup. Which
might not be that expensive but given the lack of a good dataset to
bench with, it seems a lot of additional complexity for something
we've got no visibility on. But that can be considered if someone
reports a serious performance regression from this.

So for now just revert to a "reset" cache replacement policy. If /
when we drop older versions we can switch to `functools.lru_cache` and
let the stdlib take care of this (and possibly have cache
stats). Alternatively if we get a good testing dataset one day we can
bench cache replacement policies or even provide pluggable policies.

Anyway fixes #132, closes #133