### PR TITLE
Packaging modernization & cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Checkout working copy
       uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install checkers
       run: |
         python -mpip install --upgrade pip
@@ -28,43 +28,51 @@ jobs:
     - name: black
       run: black --check --diff --color --quiet .
 
+  # REPLACE BY: job which python -mbuild, and uploads the sdist and wheel to artifacts
+  # build is not binary so can just build the one using whatever python version
   compile:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12.0-alpha - 3.12"
-          - "pypy-3.8"
-          - "pypy-3.9"
-        pyyaml-version: ["5.1.*", "5.4.*", "6.0.*", "6.*"]
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout working copy
       uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        submodules: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
     - name: Install dependency
       run: |
         python -mpip install --upgrade pip
-        python -mpip install pyyaml==${{ matrix.pyyaml-version }}
-    - name: Build regexes.py
-      run: python setup.py build_regexes -i
-    - name: Check results
+        python -mpip install build
+    - name: Build sdist and wheel
       run: |
-        # check that _regexes exists, and .eggs does not (== setuptools used our dependency)
-        test -e src/ua_parser/_regexes.py -a ! -e .eggs
+        python -mbuild
+    - name: Upload sdist
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+        retention-days: 1
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheel
+        path: dist/*.whl
+        retention-days: 1
 
   test:
+    runs-on: ubuntu-latest
+    needs: compile
     strategy:
       fail-fast: false
       matrix:
+        source:
+          - wheel
+          - sdist
+          - source
         python-version:
           - "3.8"
           - "3.9"
@@ -73,14 +81,18 @@ jobs:
           - "3.12.0-alpha - 3.12"
           - "pypy-3.8"
           - "pypy-3.9"
-    runs-on: ubuntu-latest
+        include:
+          - source: sdist
+            artifact: dist/*.tar.gz
+          - source: wheel
+            artifact: dist/*.whl
     steps:
     - name: Checkout working copy
       uses: actions/checkout@v3
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies
@@ -94,7 +106,14 @@ jobs:
             fi
         fi
         python -mpip install -r requirements_dev.txt
+    - name: download ${{ matrix.source }} artifact
+      if: matrix.artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ matrix.source }}
+        path: dist/
     - name: install package in environment
-      run: pip install .
+      run: |
+        pip install ${{ matrix.artifact || '.' }}
     - name: run tests
       run: pytest -v -Werror -Wignore::ImportWarning --doctest-glob="*.rst"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -44,15 +41,7 @@ jobs:
           - "pypy-3.8"
           - "pypy-3.9"
         pyyaml-version: ["5.1.*", "5.4.*", "6.0.*", "6.*"]
-        include:
-          - python-version: 3.6
-            os: ubuntu-20.04
-        exclude:
-          - python-version: 2.7
-            pyyaml-version: 6.0.*
-          - python-version: 2.7
-            pyyaml-version: 6.*
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout working copy
@@ -77,9 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -87,11 +73,7 @@ jobs:
           - "3.12.0-alpha - 3.12"
           - "pypy-3.8"
           - "pypy-3.9"
-        include:
-          - python-version: 3.6
-            os: ubuntu-20.04
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
-
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout working copy
       uses: actions/checkout@v3
@@ -115,10 +97,4 @@ jobs:
     - name: install package in environment
       run: pip install .
     - name: run tests
-      if: ${{ matrix.python-version != '2.7' }}
       run: pytest -v -Werror -Wignore::ImportWarning --doctest-glob="*.rst"
-    - name: run tests
-      # pprint formatting was widely altered in 3.5, so can't run
-      # doctests before then
-      if: ${{ matrix.python-version == '2.7' }}
-      run: pytest -v -Werror -Wignore::ImportWarning

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
+exclude .*
+prune .github
+global-exclude *~
+
 include README.rst
 include LICENSE
-global-exclude *~
+graft uap-core
+exclude uap-core/.*
+recursive-exclude uap-core *.js

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ format:
 	@black .
 
 release: clean
-	python setup.py sdist bdist_wheel
+	pyproject-build
 	twine upload -s dist/*
 
 .PHONY: all test clean format release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm", "PyYaml"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ua-parser"
+description = "Python port of Browserscope's user agent parser"
+version = "1.0.0a"
+readme = "README.rst"
+requires-python = ">=3.8"
+dependencies = []
+optional-dependencies = { yaml = ["PyYaml"] }
+
+license = {text = "Apache 2.0"}
+urls = {repository = "https://github.com/ua-parser/uap-python"}
+
+authors = [
+   { name = "Stephen Lamm", email = "slamm@google.com"},
+   { name = "PBS", email = "no-reply@pbs.org" },
+   { name = "Selwin Ong",  email = "selwin.ong@gmail.com" },
+   { name = "Matt Robenolt", email = "matt@ydekproductions.com" },
+   { name = "Lindsey Simon", email = "lsimon@commoner.com" },
+]
+maintainers = [
+    { name = "masklinn", email = "uap@masklinn.net" }
+]
+
+classifiers = [
+        "Development Status :: 4 - Beta",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,8 @@
-[bdist_wheel]
-universal = 1
+[options]
+packages = find:
+package_dir =
+    =src
+setup_requires = pyyaml
+
+[options.packages.find]
+where = src

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ class build_regexes(Command):
             fp.write(b"# instead, re-run `setup.py build_regexes` #\n")
             fp.write(b"############################################\n")
             fp.write(b"\n")
-            fp.write(b"from __future__ import absolute_import, unicode_literals\n")
             fp.write(b"from .user_agent_parser import (\n")
             fp.write(b"    UserAgentParser, DeviceParser, OSParser,\n")
             fp.write(b")\n")
@@ -223,14 +222,6 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/src/ua_parser/user_agent_parser.py
+++ b/src/ua_parser/user_agent_parser.py
@@ -3,8 +3,6 @@ import re
 import sys
 import warnings
 
-__author__ = "Lindsey Simon <elsigh@gmail.com>"
-
 
 class UserAgentParser(object):
     def __init__(

--- a/src/ua_parser/user_agent_parser.py
+++ b/src/ua_parser/user_agent_parser.py
@@ -1,21 +1,3 @@
-# Copyright 2009 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the 'License')
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-"""Python implementation of the UA parser."""
-
-from __future__ import absolute_import
-
 import os
 import re
 import sys

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,24 +1,3 @@
-# Copyright 2008 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the 'License')
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an 'AS IS' BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
-"""User Agent Parser Unit Tests.
-"""
-
-
-from __future__ import unicode_literals, absolute_import
-
 __author__ = "slamm@google.com (Stephen Lamm)"
 
 import logging

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,5 +1,3 @@
-__author__ = "slamm@google.com (Stephen Lamm)"
-
 import logging
 import os
 import platform

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, py39, py310, py311,
+envlist = py38, py39, py310, py311,
           pypy3.8, pypy3.9,
           docs, flake8, black
 skipsdist = True
@@ -9,10 +9,6 @@ usedevelop = True
 deps = -rrequirements_dev.txt
 commands =
     pytest -Werror --doctest-glob="*.rst" {posargs}
-
-[testenv:py27]
-# no doctesting in 2.7 because of formatting divergences
-commands = pytest -Werror {posargs}
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 envlist = py38, py39, py310, py311,
           pypy3.8, pypy3.9,
-          docs, flake8, black
+          flake8, black
 skipsdist = True
 
 [testenv]
-usedevelop = True
 deps = -rrequirements_dev.txt
 commands =
+    pip install .
     pytest -Werror --doctest-glob="*.rst" {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
- drop support for EOL'd (and soon to be EOL'd) versions of python, remove unnecessary `__future__` imports
- replace explicit invocations of `setup.py` (and recommendations thereof), as that has been deprecated for a while
- switch all but the codegen over to pyproject.toml
  - modernize the codegen code
  - use subcommands to hook codegen in, and only perform it when building a wheel (or an editable wheel though that seems a bit iffy)
- add uap-core to the sdist, as that seems sensible, and also necessary with removing codegen from the sdist path
- change the CI setup to test installation via source, wheel, and sdist, so we know all of them work correctly