### PR TITLE
Switch to tox 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
                 sudo apt install libyaml-dev
             fi
         fi
-        python -mpip install -r requirements_dev.txt
+        python -mpip install pytest pyyaml
     - name: download ${{ matrix.source }} artifact
       if: matrix.artifact
       uses: actions/download-artifact@v3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,0 @@
-pytest
-pyyaml
-tox==3.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,29 @@
 [tox]
-envlist = py38, py39, py310, py311,
-          pypy3.8, pypy3.9,
-          flake8, black
-skipsdist = True
+min_version = 4.0
+env_list = py38, py39, py310, py311,
+           pypy3.8, pypy3.9,
+           flake8, black
 
 [testenv]
-deps = -rrequirements_dev.txt
+# wheel install
+package = wheel
+# wheel is universal so can use the same wheel for all envs
+wheel_build_env = .pkg
+# for extra deps
+# extras =
+deps =
+     pytest
+     pyyaml
 commands =
-    pip install .
     pytest -Werror --doctest-glob="*.rst" {posargs}
 
 [testenv:flake8]
-skip_install = True
+package = skip
 deps = flake8
 commands = flake8 {posargs}
 
 [testenv:black]
-skip_install = True
+package = skip
 deps = black
 commands = black --check --diff .
 


### PR DESCRIPTION
Tox 4 is (finally) compatible with wheel installs & stuff, which is especially nice as the manual wheel installation was not really compatible with `tox -p` (jobs could conflict with one another and corrupt an other job's wheel).

The issue doesn't seem to happen with `tox p` which is nice, and while it's technically not *shorter* than the old tox conf, it's definitely clearer, and feels more resilient (we'll see if it is in the long run).

Also remove `requirements_dev`:

- it contained tox, which is kind-of a dev requirement but kind-of not
- as a result it caused the installation of tox in the tox envs, and in the github test images, both completely unnecessary
- the dev dependencies are pytest and pyyaml, which is shorter than spelling out `-rrequirements.dev` in full