### PR TITLE
Add tox labels to more easily run just a subset of the thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,13 @@
 [tox]
 min_version = 4.0
-env_list = py38, py39, py310, py311,
-           pypy3.8, pypy3.9,
+env_list = py3{8,9,10,11}
+           pypy3.{8,9}
            flake8, black
+labels =
+    test = py3{8,9,10,11},pypy3.{8,9}
+    cpy = py3{8,9,10,11}
+    pypy = pypy3.{8,9}
+    check = flake8, black
 
 [testenv]
 # wheel install


### PR DESCRIPTION
The label can be selected with `-m` on most tox commands, this is equivalent to selecting the corresponding envs using `-e`.

- `test` runs all the tests, in all python versions
- `check` runs the non-test checks
- `pypy` and `cpy` run the tests for their respective Python implementation

This is way more convenient when leveraging `posargs` as most of the tools are not posargs-compatible. Also easier than typing the envs in full. The only drawback is `tox list` does not display the labels.

Also use brace expansions for cleaner definitions (and easier updates), in both envlist and labels.