### PR TITLE
Disable pypy311

### DIFF
--- a/src/ua_parser/user_agent_parser.py
+++ b/src/ua_parser/user_agent_parser.py
@@ -21,9 +21,12 @@ class UserAgentParser(object):
         self.v1_replacement = v1_replacement
         self.v2_replacement = v2_replacement
 
-    def Parse(
-        self, user_agent_string: str
-    ) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str],]:
+    def Parse(self, user_agent_string: str) -> Tuple[
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+    ]:
         family, v1, v2, v3 = None, None, None, None
         match = self.user_agent_re.search(user_agent_string)
         if match:
@@ -78,9 +81,7 @@ class OSParser(object):
         self.os_v3_replacement = os_v3_replacement
         self.os_v4_replacement = os_v4_replacement
 
-    def Parse(
-        self, user_agent_string: str
-    ) -> Tuple[
+    def Parse(self, user_agent_string: str) -> Tuple[
         Optional[str],
         Optional[str],
         Optional[str],
@@ -152,9 +153,11 @@ class DeviceParser(object):
         self.brand_replacement = brand_replacement
         self.model_replacement = model_replacement
 
-    def Parse(
-        self, user_agent_string: str
-    ) -> Tuple[Optional[str], Optional[str], Optional[str],]:
+    def Parse(self, user_agent_string: str) -> Tuple[
+        Optional[str],
+        Optional[str],
+        Optional[str],
+    ]:
         device, brand, model = None, None, None
         match = self.user_agent_re.search(user_agent_string)
         if match:


### PR DESCRIPTION
Despite the suite succeeding as noted in
e9483d8fbb1e288c8842bff2766ec0a08e1a73eb, github sucks so it still marks a PR / commit as failing if non-required tests fail (red cross on the commit and "Some checks were not successful" on the PR), which sucks.

Not to mention pypy311 does not exist yet, let alone being provided by setup-python, so it can never succeed.

Therefore remove it.