### PR TITLE
Disable pypy311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           - "pypy-3.8"
           - "pypy-3.9"
           - "pypy-3.10"
-          - "pypy-3.11"
+          # - "pypy-3.11"
         include:
           - source: sdist
             artifact: dist/*.tar.gz


### PR DESCRIPTION
Despite the suite succeeding as noted in
e9483d8fbb1e288c8842bff2766ec0a08e1a73eb, github sucks so it still marks a PR / commit as failing if non-required tests fail (red cross on the commit and "Some checks were not successful" on the PR), which sucks.

Not to mention pypy311 does not exist yet, let alone being provided by setup-python, so it can never succeed.

Therefore remove it.

Apparently I fucked up something when I tried to merge #175 so that didn't work, oops