### PR TITLE
Add README note that this is unreleased

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,15 @@ Build Status
 .. image:: https://github.com/ua-parser/uap-python/actions/workflows/ci.yml/badge.svg
    :alt: CI on the master branch
 
+⚠️ THIS IS NOT THE DOCUMENTATION YOU ARE LOOKING FOR (probably) ⚠️
+------------------------------------------------------------------
+
+This is the readme for the `future 1.0 <https://github.com/ua-
+parser/uap-python/milestone/1>`_.
+
+For the current releases, see `the 0.x branch
+<https://github.com/ua-parser/uap-python/tree/0.x#uap- python>`_.
+
 Installing
 ----------
 


### PR DESCRIPTION
While switching the default branch back to master is convenient for development, it's already confusing visitors (cf #186).

At least add a note and a link to the proper page.