### PR TITLE
Split Parser and reorganise package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ class EagerWriter(Writer):
 __all__ = ["MATCHERS"]
 
 from typing import Tuple, List
-from .core import UserAgentMatcher, OSMatcher, DeviceMatcher
+from .matchers import UserAgentMatcher, OSMatcher, DeviceMatcher
 
 MATCHERS: Tuple[List[UserAgentMatcher], List[OSMatcher], List[DeviceMatcher]] = ([
 """

--- a/src/ua_parser/_matchers.pyi
+++ b/src/ua_parser/_matchers.pyi
@@ -2,7 +2,7 @@ __all__ = ["MATCHERS"]
 
 from typing import List, Tuple
 
-from .core import DeviceMatcher, OSMatcher, UserAgentMatcher
+from .matchers import DeviceMatcher, OSMatcher, UserAgentMatcher
 
 MATCHERS: Tuple[
     List[UserAgentMatcher],

--- a/src/ua_parser/basic.py
+++ b/src/ua_parser/basic.py
@@ -1,3 +1,5 @@
+__all__ = ["Resolver"]
+
 from operator import methodcaller
 from typing import List
 
@@ -7,13 +9,12 @@ from .core import (
     Matcher,
     Matchers,
     OS,
-    Parser as AbstractParser,
     PartialParseResult,
     UserAgent,
 )
 
 
-class Parser(AbstractParser):
+class Resolver:
     """A simple pure-python parser based around trying a numer of regular
     expressions in sequence for each domain, and returning a result
     when one matches.
@@ -27,9 +28,7 @@ class Parser(AbstractParser):
         self,
         matchers: Matchers,
     ) -> None:
-        self.user_agent_matchers = matchers[0]
-        self.os_matchers = matchers[1]
-        self.device_matchers = matchers[2]
+        self.user_agent_matchers, self.os_matchers, self.device_matchers = matchers
 
     def __call__(self, ua: str, domains: Domain, /) -> PartialParseResult:
         parse = methodcaller("__call__", ua)

--- a/src/ua_parser/core.py
+++ b/src/ua_parser/core.py
@@ -1,22 +1,18 @@
 import abc
-import re
 from dataclasses import dataclass
 from enum import Flag, auto
-from typing import Generic, List, Literal, Match, Optional, Pattern, Tuple, TypeVar
+from typing import Callable, Generic, List, Optional, Tuple, TypeVar
 
 __all__ = [
     "DefaultedParseResult",
     "Device",
-    "DeviceMatcher",
     "Domain",
     "Matchers",
     "OS",
-    "OSMatcher",
     "ParseResult",
-    "Parser",
     "PartialParseResult",
+    "Resolver",
     "UserAgent",
-    "UserAgentMatcher",
 ]
 
 
@@ -155,70 +151,7 @@ class PartialParseResult:
         )
 
 
-class Parser(abc.ABC):
-    @abc.abstractmethod
-    def __call__(self, ua: str, domains: Domain, /) -> PartialParseResult:
-        """Parses the ``ua`` string, returning a parse result with *at least*
-        the requested :class:`domains <Domain>` resolved (whether to success or
-        failure).
-
-        A parser may resolve more :class:`domains <Domain>` than
-        requested, but it *must not* resolve less.
-        """
-        ...
-
-    def parse(self, ua: str) -> ParseResult:
-        """Convenience method for parsing all domains, and falling back to
-        default values for all failures.
-        """
-        return self(ua, Domain.ALL).complete()
-
-    def parse_user_agent(self, ua: str) -> Optional[UserAgent]:
-        """Convenience method for parsing the :class:`UserAgent` domain,
-        falling back to the default value in case of failure.
-        """
-        return self(ua, Domain.USER_AGENT).user_agent
-
-    def parse_os(self, ua: str) -> Optional[OS]:
-        """Convenience method for parsing the :class:`OS` domain, falling back
-        to the default value in case of failure.
-        """
-        return self(ua, Domain.OS).os
-
-    def parse_device(self, ua: str) -> Optional[Device]:
-        """Convenience method for parsing the :class:`Device` domain, falling
-        back to the default value in case of failure.
-        """
-        return self(ua, Domain.DEVICE).device
-
-
-def _get(m: Match[str], idx: int) -> Optional[str]:
-    return (m[idx] or None) if 0 < idx <= m.re.groups else None
-
-
-def _replacer(repl: str, m: Match[str]) -> Optional[str]:
-    """The replacement rules are frustratingly subtle and innimical to
-    standard python fallback semantics:
-
-    - if there is a non-null replacement pattern, then it must be used with
-      match groups as template parameters (at indices 1+)
-      - the result is stripped
-      - if it is an empty string, then it's replaced by a null
-    - otherwise fallback to a (possibly optional) match group
-    - or null (device brand has no fallback)
-
-    Replacement rules only apply to OS and Device matchers, the UA
-    matcher has bespoke replacement semantics for the family (just
-    $1), and no replacement for the other fields, either there is a
-    static replacement or it falls back to the corresponding
-    (optional) match group.
-
-    """
-    if not repl:
-        return None
-
-    return re.sub(r"\$(\d)", lambda n: _get(m, int(n[1])) or "", repl).strip() or None
-
+Resolver = Callable[[str, Domain], PartialParseResult]
 
 T = TypeVar("T")
 
@@ -236,168 +169,6 @@ class Matcher(abc.ABC, Generic[T]):
     @property
     def flags(self) -> int:
         return 0
-
-
-class UserAgentMatcher(Matcher[UserAgent]):
-    regex: Pattern[str]
-    family: str
-    major: Optional[str]
-    minor: Optional[str]
-    patch: Optional[str]
-    patch_minor: Optional[str]
-
-    def __init__(
-        self,
-        regex: str,
-        family: Optional[str] = None,
-        major: Optional[str] = None,
-        minor: Optional[str] = None,
-        patch: Optional[str] = None,
-        patch_minor: Optional[str] = None,
-    ) -> None:
-        self.regex = re.compile(regex)
-        self.family = family or "$1"
-        self.major = major
-        self.minor = minor
-        self.patch = patch
-        self.patch_minor = patch_minor
-
-    def __call__(self, ua: str) -> Optional[UserAgent]:
-        if m := self.regex.search(ua):
-            return UserAgent(
-                family=(
-                    self.family.replace("$1", m[1])
-                    if "$1" in self.family
-                    else self.family
-                ),
-                major=self.major or _get(m, 2),
-                minor=self.minor or _get(m, 3),
-                patch=self.patch or _get(m, 4),
-                patch_minor=self.patch_minor or _get(m, 5),
-            )
-        return None
-
-    @property
-    def pattern(self) -> str:
-        return self.regex.pattern
-
-    def __repr__(self) -> str:
-        fields = [
-            ("family", self.family if self.family != "$1" else None),
-            ("major", self.major),
-            ("minor", self.minor),
-            ("patch", self.patch),
-            ("patch_minor", self.patch_minor),
-        ]
-        args = "".join(f", {k}={v!r}" for k, v in fields if v is not None)
-
-        return f"UserAgentMatcher({self.pattern!r}{args})"
-
-
-class OSMatcher(Matcher[OS]):
-    regex: Pattern[str]
-    family: str
-    major: str
-    minor: str
-    patch: str
-    patch_minor: str
-
-    def __init__(
-        self,
-        regex: str,
-        family: Optional[str] = None,
-        major: Optional[str] = None,
-        minor: Optional[str] = None,
-        patch: Optional[str] = None,
-        patch_minor: Optional[str] = None,
-    ) -> None:
-        self.regex = re.compile(regex)
-        self.family = family or "$1"
-        self.major = major or "$2"
-        self.minor = minor or "$3"
-        self.patch = patch or "$4"
-        self.patch_minor = patch_minor or "$5"
-
-    def __call__(self, ua: str) -> Optional[OS]:
-        if m := self.regex.search(ua):
-            family = _replacer(self.family, m)
-            if family is None:
-                raise ValueError(f"Unable to find OS family in {ua}")
-            return OS(
-                family=family,
-                major=_replacer(self.major, m),
-                minor=_replacer(self.minor, m),
-                patch=_replacer(self.patch, m),
-                patch_minor=_replacer(self.patch_minor, m),
-            )
-        return None
-
-    @property
-    def pattern(self) -> str:
-        return self.regex.pattern
-
-    def __repr__(self) -> str:
-        fields = [
-            ("family", self.family if self.family != "$1" else None),
-            ("major", self.major if self.major != "$2" else None),
-            ("minor", self.minor if self.minor != "$3" else None),
-            ("patch", self.patch if self.patch != "$4" else None),
-            ("patch_minor", self.patch_minor if self.patch_minor != "$5" else None),
-        ]
-        args = "".join(f", {k}={v!r}" for k, v in fields if v is not None)
-
-        return f"OSMatcher({self.pattern!r}{args})"
-
-
-class DeviceMatcher(Matcher[Device]):
-    regex: Pattern[str]
-    family: str
-    brand: str
-    model: str
-
-    def __init__(
-        self,
-        regex: str,
-        regex_flag: Optional[Literal["i"]] = None,
-        family: Optional[str] = None,
-        brand: Optional[str] = None,
-        model: Optional[str] = None,
-    ) -> None:
-        self.regex = re.compile(regex, flags=re.IGNORECASE if regex_flag == "i" else 0)
-        self.family = family or "$1"
-        self.brand = brand or ""
-        self.model = model or "$1"
-
-    def __call__(self, ua: str) -> Optional[Device]:
-        if m := self.regex.search(ua):
-            family = _replacer(self.family, m)
-            if family is None:
-                raise ValueError(f"Unable to find device family in {ua}")
-            return Device(
-                family=family,
-                brand=_replacer(self.brand, m),
-                model=_replacer(self.model, m),
-            )
-        return None
-
-    @property
-    def pattern(self) -> str:
-        return self.regex.pattern
-
-    @property
-    def flags(self) -> int:
-        return self.regex.flags
-
-    def __repr__(self) -> str:
-        fields = [
-            ("family", self.family if self.family != "$1" else None),
-            ("brand", self.brand or None),
-            ("model", self.model if self.model != "$1" else None),
-        ]
-        iflag = ', "i"' if self.flags & re.IGNORECASE else ""
-        args = iflag + "".join(f", {k}={v!r}" for k, v in fields if v is not None)
-
-        return f"DeviceMatcher({self.pattern!r}{args})"
 
 
 Matchers = Tuple[

--- a/src/ua_parser/loaders.py
+++ b/src/ua_parser/loaders.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 __all__ = [
-    "load_builtins",
-    "load_lazy_builtins",
-    "load_data",
-    "load_yaml",
-    "MatchersData",
-    "UserAgentDict",
-    "OSDict",
     "DeviceDict",
+    "MatchersData",
+    "OSDict",
+    "UserAgentDict",
+    "load_builtins",
+    "load_data",
+    "load_json",
+    "load_lazy",
+    "load_lazy_builtins",
+    "load_yaml",
 ]
 
 import io
@@ -28,8 +30,8 @@ from typing import (
     cast,
 )
 
-from . import lazy
-from .core import DeviceMatcher, Matchers, OSMatcher, UserAgentMatcher
+from . import lazy, matchers
+from .core import Matchers
 
 if TYPE_CHECKING:
     PathOrFile = Union[str, os.PathLike[str], io.IOBase]
@@ -93,7 +95,7 @@ DataLoader = Callable[[MatchersData], Matchers]
 def load_data(d: MatchersData) -> Matchers:
     return (
         [
-            UserAgentMatcher(
+            matchers.UserAgentMatcher(
                 p["regex"],
                 p.get("family_replacement"),
                 p.get("v1_replacement"),
@@ -104,7 +106,7 @@ def load_data(d: MatchersData) -> Matchers:
             for p in d[0]
         ],
         [
-            OSMatcher(
+            matchers.OSMatcher(
                 p["regex"],
                 p.get("os_replacement"),
                 p.get("os_v1_replacement"),
@@ -115,7 +117,7 @@ def load_data(d: MatchersData) -> Matchers:
             for p in d[1]
         ],
         [
-            DeviceMatcher(
+            matchers.DeviceMatcher(
                 p["regex"],
                 p.get("regex_flag"),
                 p.get("device_replacement"),

--- a/src/ua_parser/matchers.py
+++ b/src/ua_parser/matchers.py
@@ -1,7 +1,6 @@
 __all__ = ["UserAgentMatcher", "OSMatcher", "DeviceMatcher"]
 
 import re
-from functools import cached_property
 from typing import Literal, Optional, Pattern
 
 from .core import Device, Matcher, OS, UserAgent
@@ -9,7 +8,7 @@ from .utils import get, replacer
 
 
 class UserAgentMatcher(Matcher[UserAgent]):
-    pattern: str = ""
+    regex: Pattern[str]
     family: str
     major: Optional[str]
     minor: Optional[str]
@@ -25,7 +24,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
         patch: Optional[str] = None,
         patch_minor: Optional[str] = None,
     ) -> None:
-        self.pattern = regex
+        self.regex = re.compile(regex)
         self.family = family or "$1"
         self.major = major
         self.minor = minor
@@ -47,9 +46,9 @@ class UserAgentMatcher(Matcher[UserAgent]):
             )
         return None
 
-    @cached_property
-    def regex(self) -> Pattern[str]:
-        return re.compile(self.pattern)
+    @property
+    def pattern(self) -> str:
+        return self.regex.pattern
 
     def __repr__(self) -> str:
         fields = [
@@ -65,7 +64,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
 
 
 class OSMatcher(Matcher[OS]):
-    pattern: str = ""
+    regex: Pattern[str]
     family: str
     major: str
     minor: str
@@ -81,7 +80,7 @@ class OSMatcher(Matcher[OS]):
         patch: Optional[str] = None,
         patch_minor: Optional[str] = None,
     ) -> None:
-        self.pattern = regex
+        self.regex = re.compile(regex)
         self.family = family or "$1"
         self.major = major or "$2"
         self.minor = minor or "$3"
@@ -102,9 +101,9 @@ class OSMatcher(Matcher[OS]):
             )
         return None
 
-    @cached_property
-    def regex(self) -> Pattern[str]:
-        return re.compile(self.pattern)
+    @property
+    def pattern(self) -> str:
+        return self.regex.pattern
 
     def __repr__(self) -> str:
         fields = [
@@ -120,8 +119,7 @@ class OSMatcher(Matcher[OS]):
 
 
 class DeviceMatcher(Matcher[Device]):
-    pattern: str = ""
-    flags: int = 0
+    regex: Pattern[str]
     family: str
     brand: str
     model: str
@@ -134,8 +132,7 @@ class DeviceMatcher(Matcher[Device]):
         brand: Optional[str] = None,
         model: Optional[str] = None,
     ) -> None:
-        self.pattern = regex
-        self.flags = re.IGNORECASE if regex_flag == "i" else 0
+        self.regex = re.compile(regex, flags=re.IGNORECASE if regex_flag == "i" else 0)
         self.family = family or "$1"
         self.brand = brand or ""
         self.model = model or "$1"
@@ -152,9 +149,13 @@ class DeviceMatcher(Matcher[Device]):
             )
         return None
 
-    @cached_property
-    def regex(self) -> Pattern[str]:
-        return re.compile(self.pattern, flags=self.flags)
+    @property
+    def pattern(self) -> str:
+        return self.regex.pattern
+
+    @property
+    def flags(self) -> int:
+        return self.regex.flags
 
     def __repr__(self) -> str:
         fields = [

--- a/src/ua_parser/re2.py
+++ b/src/ua_parser/re2.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+__all__ = ["Resolver"]
 
 import re
 from typing import List
@@ -11,13 +11,12 @@ from .core import (
     Matcher,
     Matchers,
     OS,
-    Parser as AbstractParser,
     PartialParseResult,
     UserAgent,
 )
 
 
-class Parser(AbstractParser):
+class Resolver:
     ua: re2.Filter
     user_agent_matchers: List[Matcher[UserAgent]]
     os: re2.Filter

--- a/src/ua_parser/threaded.py
+++ b/src/ua_parser/threaded.py
@@ -6,15 +6,15 @@ import time
 from typing import Iterable
 
 from . import (
-    BasicParser,
-    CachingParser,
+    BasicResolver,
+    CachingResolver,
     Clearing,
     Locking,
     LRU,
     Parser,
     load_builtins,
 )
-from .re2 import Parser as Re2Parser
+from .re2 import Resolver as Re2Resolver
 
 
 def worker(
@@ -54,11 +54,11 @@ def main() -> None:
     args = ap.parse_args()
 
     lines = list(args.file)
-    basic = BasicParser(load_builtins())
+    basic = BasicResolver(load_builtins())
     for name, parser in [
-        ("clearing", CachingParser(basic, Clearing(CACHESIZE))),
-        ("LRU", CachingParser(basic, Locking(LRU(CACHESIZE)))),
-        ("re2", Re2Parser(load_builtins())),
+        ("clearing", CachingResolver(basic, Clearing(CACHESIZE))),
+        ("LRU", CachingResolver(basic, Locking(LRU(CACHESIZE)))),
+        ("re2", Re2Resolver(load_builtins())),
     ]:
         # randomize the dataset for each thread, predictably, to
         # simulate distributed load (not great but better than

--- a/src/ua_parser/utils.py
+++ b/src/ua_parser/utils.py
@@ -1,0 +1,30 @@
+import re
+from typing import Match, Optional
+
+
+def get(m: Match[str], idx: int) -> Optional[str]:
+    return (m[idx] or None) if 0 < idx <= m.re.groups else None
+
+
+def replacer(repl: str, m: Match[str]) -> Optional[str]:
+    """The replacement rules are frustratingly subtle and innimical to
+    standard python fallback semantics:
+
+    - if there is a non-null replacement pattern, then it must be used with
+      match groups as template parameters (at indices 1+)
+      - the result is stripped
+      - if it is an empty string, then it's replaced by a null
+    - otherwise fallback to a (possibly optional) match group
+    - or null (device brand has no fallback)
+
+    Replacement rules only apply to OS and Device matchers, the UA
+    matcher has bespoke replacement semantics for the family (just
+    $1), and no replacement for the other fields, either there is a
+    static replacement or it falls back to the corresponding
+    (optional) match group.
+
+    """
+    if not repl:
+        return None
+
+    return re.sub(r"\$(\d)", lambda n: get(m, int(n[1])) or "", repl).strip() or None

--- a/tests/test_caches.py
+++ b/tests/test_caches.py
@@ -1,19 +1,18 @@
 from collections import OrderedDict
 
 from ua_parser import (
-    BasicParser,
-    CachingParser,
+    BasicResolver,
+    CachingResolver,
     Clearing,
     Device,
-    DeviceMatcher,
     Domain,
     LRU,
     OS,
-    OSMatcher,
+    Parser,
     PartialParseResult,
     UserAgent,
-    UserAgentMatcher,
 )
+from ua_parser.matchers import DeviceMatcher, OSMatcher, UserAgentMatcher
 
 
 def test_clearing():
@@ -21,7 +20,7 @@ def test_clearing():
     entries.
     """
     cache = Clearing(2)
-    p = CachingParser(BasicParser(([], [], [])), cache)
+    p = Parser(CachingResolver(BasicResolver(([], [], [])), cache))
 
     p.parse("a")
     p.parse("b")
@@ -42,7 +41,7 @@ def test_lru():
     popped LRU-first.
     """
     cache = LRU(2)
-    p = CachingParser(BasicParser(([], [], [])), cache)
+    p = Parser(CachingResolver(BasicResolver(([], [], [])), cache))
 
     p.parse("a")
     p.parse("b")
@@ -69,15 +68,17 @@ def test_backfill():
     existing entry when new parts get parsed.
     """
     cache = Clearing(2)
-    p = CachingParser(
-        BasicParser(
-            (
-                [UserAgentMatcher("(a)")],
-                [OSMatcher("(a)")],
-                [DeviceMatcher("(a)")],
-            )
-        ),
-        cache,
+    p = Parser(
+        CachingResolver(
+            BasicResolver(
+                (
+                    [UserAgentMatcher("(a)")],
+                    [OSMatcher("(a)")],
+                    [DeviceMatcher("(a)")],
+                )
+            ),
+            cache,
+        )
     )
 
     p.parse_user_agent("a")

--- a/tests/test_convenience_parser.py
+++ b/tests/test_convenience_parser.py
@@ -1,0 +1,13 @@
+from ua_parser import Parser, ParseResult, PartialParseResult
+
+
+def test_parser_utility() -> None:
+    """Tests that ``Parser``'s methods to behave as procedural
+    helpers, for users who may not wish to instantiate a parser or
+    something.
+
+    Sadly the typing doesn't really play nicely with that.
+
+    """
+    r = Parser.parse(lambda s, d: PartialParseResult(d, None, None, None, s), "a")  # type: ignore
+    assert r == ParseResult(None, None, None, "a")

--- a/tests/test_parsers_basics.py
+++ b/tests/test_parsers_basics.py
@@ -1,17 +1,17 @@
 import io
 
 from ua_parser import (
-    BasicParser,
+    BasicResolver,
     Domain,
     PartialParseResult,
     UserAgent,
-    UserAgentMatcher,
-    load_yaml,
 )
+from ua_parser.loaders import load_yaml
+from ua_parser.matchers import UserAgentMatcher
 
 
 def test_trivial_matching():
-    p = BasicParser(([UserAgentMatcher("(a)")], [], []))
+    p = BasicResolver(([UserAgentMatcher("(a)")], [], []))
 
     assert p("x", Domain.ALL) == PartialParseResult(
         string="x",
@@ -31,7 +31,7 @@ def test_trivial_matching():
 
 
 def test_partial():
-    p = BasicParser(([UserAgentMatcher("(a)")], [], []))
+    p = BasicResolver(([UserAgentMatcher("(a)")], [], []))
 
     assert p("x", Domain.USER_AGENT) == PartialParseResult(
         string="x",
@@ -60,7 +60,7 @@ os_parsers: []
 device_parsers: []
 """
     )
-    p = BasicParser(load_yaml(f))
+    p = BasicResolver(load_yaml(f))
 
     assert p("x", Domain.USER_AGENT) == PartialParseResult(
         string="x",


### PR DESCRIPTION
Parser turns out to not really make sense as a superclass / ABC: it really only has one useful method, and because parsers use delegation there's no real way to override the utility methods / shortcuts, so they're only useful on the caller / client side but they constrain the implementor (who has to extend the ABC and then possibly deal with multiple-inheritance shenanigans).

Making the core object just a callable protocol instead makes the implementation somewhat simpler and more flexible (e.g. just a function or HoF can be a "parser"), however the convenient utility methods *are* important for end users and should not be discounted.

For that, keep a wrapper `Parser` object which can be wrapped around a "parser" in order to provide the additional convenience (similar to the free functions at the root). Importantly, `Parser` methods can also be used as free functions by passing a "parser" as `self`, they are intended to be compatible. It doesn't work super well from the typechecking perspective, but it works fine enough.

Consideration was given to making the free functions at the package root parametric on the parser e.g.

    def parse(ua: str, resolver: Optional[Resolver] = None, /) -> ParseResult:
        if resolver is None:
            from . import parser as resolver

        return resolver(ua, Domain.ALL).complete()

but that feels like it would be pretty error prone, in the sense that it would be too easy to forget to pass in the resolver, compared to consistently resolving via a bespoke parser, or just installing a parser globally.

Also move things around a bit:

- move matcher utility functions out of the core, un-prefix them since we're using `__all__` for visibility anyway
- move eager matchers out of the core, similar to the lazy matchers

Fixes #189