### PR TITLE
Allow using tox to reformat the working copy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands = ruff check {posargs}
 [testenv:black]
 package = skip
 deps = ruff
-commands = ruff format --diff {posargs:.}
+commands = ruff format {posargs:--diff}
 
 [testenv:typecheck]
 package = skip


### PR DESCRIPTION
By default, tox should check that the code is correctly formatted CI-style. However it can be useful to use it to *fix* the code as well. By using `--diff` as an overridable default,

    tox -eblack --

becomes an easy way to reformat the working copy. Technically it's not that much shorter than `ruff format`, but if the previous command was `tox -eblack` (to check formatting) then it becomes a smaller change, and I don't have to remember the ruff invocation.