### PR TITLE
Suppress "Compile called before Add" in re2.Filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-classes = ["LRU", "OS"]
+classes = ["OS"]
+known-first-party = ["ua_parser"]
 combine-as-imports = true
 
 [tool.mypy]

--- a/tests/test_re2.py
+++ b/tests/test_re2.py
@@ -1,0 +1,13 @@
+import pytest  # type: ignore
+
+from ua_parser import Domain, PartialParseResult
+
+re2 = pytest.importorskip("ua_parser.re2")
+
+
+def test_empty(capfd: pytest.CaptureFixture[str]) -> None:
+    r = re2.Resolver(([], [], []))
+    assert r("", Domain.ALL) == PartialParseResult(Domain.ALL, None, None, None, "")
+    out, err = capfd.readouterr()
+    assert out == ""
+    assert err == ""


### PR DESCRIPTION
When compiling an empty set, ``FilteredRE2::Compile`` logs a warning to stderr which can not be suppressed (https://github.com/google/re2/issues/485).

Replace `re2.Filter` by a null object if the corresponding matchers list is empty: not only do we need to skip `Filter.Compile` to suppress the warning message, we need to skip `Filter.Match` or the program will segfault (https://github.com/google/re2/issues/484). Using a null object seems safer and more reliable than adding conditionals, even if it requires more code and reindenting half the file.

Doing this also seems safer than my first instinct of trying to use low-level fd redirection: fd redirection suffers from race
conditions[^thread] and could suffer from other cross-platform compatibility issues (e.g. does every python-supported OS have stderr on fd 2 and correctly supports dup, dup2, and close?)

[^thread]: AFAIK CPython does not provide a python-level GIL-pin feature (even less so with the GILectomy plans), so we have no way to prevent context-switching and any message sent to stderr by sibling threads would be lost