### PR TITLE
Avoid eviction on entry replacement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = ["F", "E", "W", "I", "RET", "RUF", "PT"]
 ignore = [
     "RET505",  # elif after return
     "E501",  # line too long, formatter should take care of the fixable ones
+    "E721",  # I'll compare types with `is` if I want
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
`*Result` objects are immutable, thus if a `PartialResult` gets filled further it has to be re-set into the cache.

This does not change the cache size, but because the current S3 and SIEVE implementations unconditionally check the cache size on `__setitem__` they may evict an entry unnecessarily.

Fix that: if there is already a valid cache entry for the key, just update it in place instead of trying to evict then creating a brand new entry.

Also update the LRU to pre-check for size (and presence as well), this may make setting a bit more expensive than post-check but it avoids "wronging" the user by bypassing the limit they set.

Fixes #201