### PR TITLE
Rename the string regex attribute of matchers to `regex`

### DIFF
--- a/src/ua_parser/core.py
+++ b/src/ua_parser/core.py
@@ -240,7 +240,7 @@ class Matcher(abc.ABC, Generic[T]):
 
     @property
     @abc.abstractmethod
-    def pattern(self) -> str:
+    def regex(self) -> str:
         """Returns the matcher's pattern."""
         ...
 

--- a/src/ua_parser/matchers.py
+++ b/src/ua_parser/matchers.py
@@ -13,7 +13,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
 
     """
 
-    regex: Pattern[str]
+    pattern: Pattern[str]
     family: str
     major: Optional[str]
     minor: Optional[str]
@@ -29,7 +29,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
         patch: Optional[str] = None,
         patch_minor: Optional[str] = None,
     ) -> None:
-        self.regex = re.compile(regex)
+        self.pattern = re.compile(regex)
         self.family = family or "$1"
         self.major = major
         self.minor = minor
@@ -37,7 +37,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
         self.patch_minor = patch_minor
 
     def __call__(self, ua: str) -> Optional[UserAgent]:
-        if m := self.regex.search(ua):
+        if m := self.pattern.search(ua):
             return UserAgent(
                 family=(
                     self.family.replace("$1", m[1])
@@ -52,8 +52,8 @@ class UserAgentMatcher(Matcher[UserAgent]):
         return None
 
     @property
-    def pattern(self) -> str:
-        return self.regex.pattern
+    def regex(self) -> str:
+        return self.pattern.pattern
 
     def __repr__(self) -> str:
         fields = [
@@ -65,7 +65,7 @@ class UserAgentMatcher(Matcher[UserAgent]):
         ]
         args = "".join(f", {k}={v!r}" for k, v in fields if v is not None)
 
-        return f"UserAgentMatcher({self.pattern!r}{args})"
+        return f"UserAgentMatcher({self.regex!r}{args})"
 
 
 class OSMatcher(Matcher[OS]):
@@ -74,7 +74,7 @@ class OSMatcher(Matcher[OS]):
 
     """
 
-    regex: Pattern[str]
+    pattern: Pattern[str]
     family: str
     major: str
     minor: str
@@ -90,7 +90,7 @@ class OSMatcher(Matcher[OS]):
         patch: Optional[str] = None,
         patch_minor: Optional[str] = None,
     ) -> None:
-        self.regex = re.compile(regex)
+        self.pattern = re.compile(regex)
         self.family = family or "$1"
         self.major = major or "$2"
         self.minor = minor or "$3"
@@ -98,7 +98,7 @@ class OSMatcher(Matcher[OS]):
         self.patch_minor = patch_minor or "$5"
 
     def __call__(self, ua: str) -> Optional[OS]:
-        if m := self.regex.search(ua):
+        if m := self.pattern.search(ua):
             family = replacer(self.family, m)
             if family is None:
                 raise ValueError(f"Unable to find OS family in {ua}")
@@ -112,8 +112,8 @@ class OSMatcher(Matcher[OS]):
         return None
 
     @property
-    def pattern(self) -> str:
-        return self.regex.pattern
+    def regex(self) -> str:
+        return self.pattern.pattern
 
     def __repr__(self) -> str:
         fields = [
@@ -125,7 +125,7 @@ class OSMatcher(Matcher[OS]):
         ]
         args = "".join(f", {k}={v!r}" for k, v in fields if v is not None)
 
-        return f"OSMatcher({self.pattern!r}{args})"
+        return f"OSMatcher({self.regex!r}{args})"
 
 
 class DeviceMatcher(Matcher[Device]):
@@ -134,7 +134,7 @@ class DeviceMatcher(Matcher[Device]):
 
     """
 
-    regex: Pattern[str]
+    pattern: Pattern[str]
     family: str
     brand: str
     model: str
@@ -147,13 +147,15 @@ class DeviceMatcher(Matcher[Device]):
         brand: Optional[str] = None,
         model: Optional[str] = None,
     ) -> None:
-        self.regex = re.compile(regex, flags=re.IGNORECASE if regex_flag == "i" else 0)
+        self.pattern = re.compile(
+            regex, flags=re.IGNORECASE if regex_flag == "i" else 0
+        )
         self.family = family or "$1"
         self.brand = brand or ""
         self.model = model or "$1"
 
     def __call__(self, ua: str) -> Optional[Device]:
-        if m := self.regex.search(ua):
+        if m := self.pattern.search(ua):
             family = replacer(self.family, m)
             if family is None:
                 raise ValueError(f"Unable to find device family in {ua}")
@@ -165,12 +167,16 @@ class DeviceMatcher(Matcher[Device]):
         return None
 
     @property
-    def pattern(self) -> str:
-        return self.regex.pattern
+    def regex(self) -> str:
+        return self.pattern.pattern
+
+    @property
+    def regex_flag(self) -> str:
+        return "i" if self.flags & re.IGNORECASE else ""
 
     @property
     def flags(self) -> int:
-        return self.regex.flags
+        return self.pattern.flags
 
     def __repr__(self) -> str:
         fields = [
@@ -181,4 +187,4 @@ class DeviceMatcher(Matcher[Device]):
         iflag = ', "i"' if self.flags & re.IGNORECASE else ""
         args = iflag + "".join(f", {k}={v!r}" for k, v in fields if v is not None)
 
-        return f"DeviceMatcher({self.pattern!r}{args})"
+        return f"DeviceMatcher({self.regex!r}{args})"

--- a/src/ua_parser/re2.py
+++ b/src/ua_parser/re2.py
@@ -38,7 +38,7 @@ class Resolver:
         if self.user_agent_matchers:
             self.ua = re2.Filter()
             for u in self.user_agent_matchers:
-                self.ua.Add(u.pattern)
+                self.ua.Add(u.regex)
             self.ua.Compile()
         else:
             self.ua = DummyFilter()
@@ -46,7 +46,7 @@ class Resolver:
         if self.os_matchers:
             self.os = re2.Filter()
             for o in self.os_matchers:
-                self.os.Add(o.pattern)
+                self.os.Add(o.regex)
             self.os.Compile()
         else:
             self.os = DummyFilter()
@@ -58,9 +58,9 @@ class Resolver:
                 # no pattern uses global flags, but since they're not
                 # supported in JS that seems safe.
                 if d.flags & re.IGNORECASE:
-                    self.devices.Add("(?i)" + d.pattern)
+                    self.devices.Add("(?i)" + d.regex)
                 else:
-                    self.devices.Add(d.pattern)
+                    self.devices.Add(d.regex)
             self.devices.Compile()
         else:
             self.devices = DummyFilter()


### PR DESCRIPTION
It's kinda dumb that I didn't do that in the first place and I'm not entirely sure why I missed it...

Anyway there is no reason to make `pattern` be the string pattern and `regex` be the compiled pattern, that unnecessarily diverges from the regexes.yaml naming for the corresponding attribute which is a shame, and the compiled regex in python is... `re.Pattern`, so it makes more sense on both axis to have `pattern: re.Pattern[str]` and `regex: str`.

Also add a `regex_flag` attribute/property on the device matchers for the string version of the flags.

With that, maybe we could build the matchers straight from the source records by direct unpacking, as well as simplify the codegen through the magic of doing less? This probably requires benching to see if

     foo(**{'foo': 'bar'})

has the same efficiency as

    foo(foo=bar)

if it does, then there's no reason to bother with reformatting parser records to the current

    foo(bar)