### PR TITLE
Ruff does not understand `contextlib.suppress`

### DIFF
--- a/src/ua_parser/__init__.py
+++ b/src/ua_parser/__init__.py
@@ -40,7 +40,7 @@ __all__ = [
     "parse_user_agent",
 ]
 
-import contextlib
+import importlib.util
 from typing import Callable, Optional
 
 from .basic import Resolver as BasicResolver
@@ -59,7 +59,7 @@ from .core import (
 from .loaders import load_builtins, load_lazy_builtins
 
 Re2Resolver: Optional[Callable[[Matchers], Resolver]] = None
-with contextlib.suppress(ImportError):
+if importlib.util.find_spec("re2"):
     from .re2 import Resolver as Re2Resolver
 
 


### PR DESCRIPTION
Not entirely clear when F811 started triggering on this pattern (it didn't 3 months ago but is now unhappy with this).

Use `find_spec` to perform a conditional import rather than recover from a failing import. This is generally less efficient, but given it's only done at import it likely doesnt matter.

- successfully importing a module takes about 65ns
- successfully find_spec-ing a module takes about 280ns
- unsuccessfully find_spec-ing a module takes about 21*µ*s
- unsuccessfully importing a modules (then recovering) takes about 26µs