### PR TITLE
Add graal to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
           - "pypy-3.9"
           - "pypy-3.10"
           # - "pypy-3.11"
-          # don't enable graal because it's slower than even pypy and
-          # fails because oracle/graalpython#385
-          # - "graalpy-23"
+          - "graalpy-24"
         include:
           - source: sdist
             artifact: dist/*.tar.gz


### PR DESCRIPTION
For reference, [as of opening this PR](https://github.com/ua-parser/uap-python/actions/runs/11091824166), the `run tests` step takes:

- 31~32s on CPython 3.12 (https://github.com/ua-parser/uap-python/actions/runs/11091824166/job/30816102051?pr=220)
- 126~144s on pypy-3.10 (https://github.com/ua-parser/uap-python/actions/runs/11091824166/job/30816102468?pr=220, https://github.com/ua-parser/uap-python/actions/runs/11091824166/job/30816101564?pr=220)
- 120s on graal-24 (https://github.com/ua-parser/uap-python/actions/runs/11091824166/job/30816102553?pr=220)

Notes:
- graal-24 seems to run a *lot* faster than graal-23 did, I remember much worse from the previous attempt, even if it's still a good 4x behind cpython it's competitive with pypy
- although the overall CI run is way behind (by a minute) because graal has much higher "set up python" and "install test dependencies" overhead, the former is almost certainly because doesn't find graal in cache (why tho?), the latter I'm less sure both have to build a pyyaml wheel from src dist but graal triggers a bunch of downloads & tries to install libyaml-dev so there might be missing bits for graal in the CI setup

Caveats:

- cpython also runs re2 tests, though that ought be basically nil compared to running the "pure python" test suite twice