### PR TITLE
Add py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,12 @@
-exclude .*
-prune .github
-global-exclude *~
-
 include README.rst
 include LICENSE
+
 graft uap-core
-exclude uap-core/.*
-recursive-exclude uap-core *.js
+
+prune .github
+prune uap-core/.github
+global-exclude *~
+global-exclude .*
+global-exclude *.js
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ classifiers = [
         "Programming Language :: Python :: Implementation :: PyPy"
 ]
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"ua_parser" = ["py.typed"]
+
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "RET", "RUF", "PT"]
 ignore = [


### PR DESCRIPTION
This marker file is necessary when *distributing* libraries, in order for the consumer side to know that the library is typed and for typecheckers to know to use it directly rather than look for a stub package (or give up on typing).

Closes #218