### PR TITLE
Fix perf scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ classifiers = [
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        "Programming Language :: Python :: Implementation :: GraalPy",
+        # no graalpy classifier yet (pypa/trove-classifiers#188)
+        # "Programming Language :: Python :: Implementation :: GraalPy",
 ]
 
 [project.optional-dependencies]
@@ -53,6 +54,12 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "ua_parser" = ["py.typed"]
+
+[tool.ruff]
+exclude = [
+    "src/ua_parser/_lazy.py",
+    "src/ua_parser/_matchers.py",
+]
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "RET", "RUF", "PT"]

--- a/src/ua_parser/__main__.py
+++ b/src/ua_parser/__main__.py
@@ -11,7 +11,7 @@ import random
 import sys
 import threading
 import time
-import tracemalloc
+import types
 from typing import (
     Any,
     Callable,
@@ -38,8 +38,15 @@ from . import (
 )
 from .caching import Cache, Local
 from .loaders import load_builtins, load_yaml
-from .re2 import Resolver as Re2Resolver
-from .regex import Resolver as RegexResolver
+
+try:
+    from .re2 import Resolver as Re2Resolver
+except ImportError:
+    pass
+try:
+    from .regex import Resolver as RegexResolver
+except ImportError:
+    pass
 from .user_agent_parser import Parse
 
 CACHEABLE = {
@@ -59,6 +66,17 @@ CACHES.update(
         caching.Sieve,
     ]
 )
+
+try:
+    import tracemalloc
+except ImportError:
+    snapshot = types.SimpleNamespace(
+        compare_to=lambda _1, _2: [],
+    )
+    tracemalloc = types.SimpleNamespace(  # type: ignore
+        start=lambda: None,
+        take_snapshot=lambda: snapshot,
+    )
 
 
 def get_rules(parsers: List[str], regexes: Optional[io.IOBase]) -> Matchers:

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 min_version = 4.0
 env_list = py3{9,10,11,12}
-           pypy3.10
-           #graalpy-24
+           pypy
+           graalpy
            flake8, black, typecheck
 labels =
-    test = py3{9,10,11,12},pypy3.10#,graalpy-24
+    test = py3{9,10,11,12},pypy,graalpy
     cpy = py3{9,10,11,12}
-    pypy = pypy3.10
-    #graal = graalpy-24
+    pypy = pypy
+    graal = graalpy
     check = flake8, black, typecheck
 
 [testenv]
@@ -26,13 +26,7 @@ deps =
 commands =
     pytest -Werror --doctest-glob="*.rst" {posargs}
 
-[testenv:pypy3.10]
-deps =
-     pytest
-     pyyaml
-     ua-parser-rs
-
-[testenv:graalpy-24]
+[testenv:{pypy,graalpy}]
 deps =
      pytest
      pyyaml


### PR DESCRIPTION
- enable graal on tox (24.1 with master's virtualenv plugin seems to work)
- make tracemalloc optional in CLI script (doesn't work in pypy)
- add regex to CLI script
- comment graalpy trove classifier (doesn't exist yet)

fixes #206, fixes part of #207