### PR TITLE
Add release workflow for ua-parser

### DIFF
--- a/.github/workflows/release-builtins.yml
+++ b/.github/workflows/release-builtins.yml
@@ -1,4 +1,6 @@
-name: Publish Python distribution to PyPI and TestPyPI
+name: Publish ua-parser builtins
+
+run-name: Publish ${{ inputs.tag || 'master' }} to ${{ inputs.environment || 'dummy' }}
 
 on:
   schedule:
@@ -67,6 +69,8 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        verbose: true
 
   publish-to-pypi:
     name: publish
@@ -88,3 +92,5 @@ jobs:
         path: dist/
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,49 @@
+name: Publish ua-parser
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+env:
+  ENVNAME: ${{ github.event_name == 'release' && 'pypi' || 'testpypi' }}
+  ENVURL: https://${{ github.event_name != 'release' && 'test.' || '' }}pypy.org/p/ua-parser
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ github.event_name == 'release' && 'pypi' || 'testpypi' }}
+      url: https://${{ github.event_name != 'release' && 'test.' || '' }}pypy.org/p/ua-parser
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Checkout working copy
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install dependency
+      run: |
+        python -mpip install --upgrade pip
+        python -mpip install build
+    - name: Build sdist and wheel
+      run: python -mbuild
+    - name: Publish to testpypi
+      if: ${{ env.ENVNAME == 'testpypi' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        verbose: true
+        password: ${{ secrets.PUBLISH_TOKEN }}
+    - name: Publish to pypi
+      if: ${{ env.ENVNAME == 'pypi' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
+        password: ${{ secrets.PUBLISH_TOKEN }}


### PR DESCRIPTION
Also update the release workflow for the builtins:

- configure `run-name` to print the inputs (otherwise they're not printed anywhere and it's hard to check them)
- make the publish action `verbose`
- don't fail testpypi on duplicates (easier to test workflow files)