### PR TITLE
Fix a bunch of URLs

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   ENVNAME: ${{ github.event_name == 'release' && 'pypi' || 'testpypi' }}
-  ENVURL: https://${{ github.event_name != 'release' && 'test.' || '' }}pypy.org/p/ua-parser
 
 jobs:
   release:
@@ -15,7 +14,7 @@ jobs:
 
     environment:
       name: ${{ github.event_name == 'release' && 'pypi' || 'testpypi' }}
-      url: https://${{ github.event_name != 'release' && 'test.' || '' }}pypy.org/p/ua-parser
+      url: https://${{ github.event_name != 'release' && 'test.' || '' }}pypi.org/p/ua-parser
 
     permissions:
       id-token: write

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Build Status
    :alt: CI on the master branch
 
 .. image:: https://readthedocs.org/projects/uap-python/badge/?version=latest
-   :target: https://readthedocs.org/project/uap-python/en/latest/
+   :target: https://uap-python.readthedocs.io/en/latest/
    :alt: Documentation Status
 
 Installing
@@ -42,7 +42,7 @@ ua-parser supports CPython 3.9 and newer, recent pypy (supporting
    See `builtin resolvers`_ for more explanation of the tradeoffs
    between the different options.
 
-.. _builtin resolvers: https://readthedocs.org/ua-parser/uap-python/guides#builtin-resolvers
+.. _builtin resolvers: https://uap-python.readthedocs.io/en/latest/guides.html#builtin-resolvers
 
 Quick Start
 -----------
@@ -114,4 +114,4 @@ Upgrading
 
 Upgrading from 0.x? See `the upgrade guide`_.
 
-.. _the upgrade guide: https://readthedocs.org/ua-parser/uap-python/advanced/migration
+.. _the upgrade guide: https://uap-python.readthedocs.io/en/latest/advanced/migration.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ua-parser"
 description = "Python port of Browserscope's user agent parser"
-version = "1.0.0a1"
+version = "1.0.0a2"
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = ["ua-parser-builtins"]
 
 license = {text = "Apache 2.0"}
-urls = {repository = "https://github.com/ua-parser/uap-python"}
 
 authors = [
    { name = "Stephen Lamm", email = "slamm@google.com"},
@@ -43,6 +42,11 @@ classifiers = [
         # no graalpy classifier yet (pypa/trove-classifiers#188)
         # "Programming Language :: Python :: Implementation :: GraalPy",
 ]
+
+[project.urls]
+documentation = "https://uap-python.readthedocs.io"
+repository = "https://github.com/ua-parser/uap-python"
+issues = "https://github.com/ua-parser/uap-python/issues"
 
 [project.optional-dependencies]
 yaml = ["PyYaml"]


### PR DESCRIPTION
- it's pypi.org not pypy.org
- rtfd doesn't serve docs out of its main domain (which makes sense since docs can contain arbitrary JS)
- add the doc and issues to the project URLs