### PR TITLE
Specify the PyPy version to target in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 min_version = 4.0
 env_list = py3{9,10,11,12}
-           pypy
+           pypy310
            graalpy
            flake8, black, typecheck
 labels =
-    test = py3{9,10,11,12},pypy,graalpy
+    test = py3{9,10,11,12},pypy310,graalpy
     cpy = py3{9,10,11,12}
     pypy = pypy3.10
     graal = graalpy-24
@@ -27,7 +27,7 @@ deps =
 commands =
     pytest -Werror --doctest-glob="*.rst" {posargs}
 
-[testenv:{pypy,graalpy}]
+[testenv:{pypy310,graalpy}]
 deps =
      pytest
      pyyaml


### PR DESCRIPTION
This helps ensure that PyPy 3.10 is actually getting tested locally.