### PR TITLE
test_legacy formatting fixes

### DIFF
--- a/src/ua_parser/__main__.py
+++ b/src/ua_parser/__main__.py
@@ -101,7 +101,7 @@ def run_stdout(args: argparse.Namespace) -> None:
     lines = list(args.file)
     count = len(lines)
     uniques = len(set(lines))
-    print(f"{args.file.name}: {count} lines, {uniques} unique ({uniques/count:.0%})")
+    print(f"{args.file.name}: {count} lines, {uniques} unique ({uniques / count:.0%})")
 
     rules = get_rules(args.bases, args.regexes)
 
@@ -320,7 +320,7 @@ def run_hitrates(args: argparse.Namespace) -> None:
                 overhead / cache_size,
             )
         print(
-            f"{cache.__name__.lower():8}({cache_size:{w}}): {(total - misses.count)/total*100:2.0f}% hit rate {diff}"
+            f"{cache.__name__.lower():8}({cache_size:{w}}): {(total - misses.count) / total * 100:2.0f}% hit rate {diff}"
         )
         del misses, parser
 
@@ -378,7 +378,7 @@ def run_threaded(args: argparse.Namespace) -> None:
         totlines = len(lines) * args.threads
         # runtime in us
         t = (time.perf_counter_ns() - st) / 1000
-        print(f"{t/totlines:>4.0f}us/line", flush=True)
+        print(f"{t / totlines:>4.0f}us/line", flush=True)
 
 
 EPILOG = """For good results the sample `file` should be an actual

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -107,18 +107,18 @@ class TestParse:
 
             result = {}
             result = user_agent_parser.ParseUserAgent(user_agent_string)
-            assert (
-                result == expected
-            ), "UA: {0}\n expected<{1}, {2}, {3}, {4}> != actual<{5}, {6}, {7}, {8}>".format(
-                user_agent_string,
-                expected["family"],
-                expected["major"],
-                expected["minor"],
-                expected["patch"],
-                result["family"],
-                result["major"],
-                result["minor"],
-                result["patch"],
+            assert result == expected, (
+                "UA: {0}\n expected<{1}, {2}, {3}, {4}> != actual<{5}, {6}, {7}, {8}>".format(
+                    user_agent_string,
+                    expected["family"],
+                    expected["major"],
+                    expected["minor"],
+                    expected["patch"],
+                    result["family"],
+                    result["major"],
+                    result["minor"],
+                    result["patch"],
+                )
             )
             assert (
                 len(user_agent_parser._PARSE_CACHE) <= user_agent_parser.MAX_CACHE_SIZE
@@ -143,20 +143,20 @@ class TestParse:
             }
 
             result = user_agent_parser.ParseOS(user_agent_string)
-            assert (
-                result == expected
-            ), "UA: {0}\n expected<{1} {2} {3} {4} {5}> != actual<{6} {7} {8} {9} {10}>".format(
-                user_agent_string,
-                expected["family"],
-                expected["major"],
-                expected["minor"],
-                expected["patch"],
-                expected["patch_minor"],
-                result["family"],
-                result["major"],
-                result["minor"],
-                result["patch"],
-                result["patch_minor"],
+            assert result == expected, (
+                "UA: {0}\n expected<{1} {2} {3} {4} {5}> != actual<{6} {7} {8} {9} {10}>".format(
+                    user_agent_string,
+                    expected["family"],
+                    expected["major"],
+                    expected["minor"],
+                    expected["patch"],
+                    expected["patch_minor"],
+                    result["family"],
+                    result["major"],
+                    result["minor"],
+                    result["patch"],
+                    result["patch_minor"],
+                )
             )
 
     def runDeviceTestsFromYAML(self, file_name):
@@ -176,16 +176,16 @@ class TestParse:
             }
 
             result = user_agent_parser.ParseDevice(user_agent_string)
-            assert (
-                result == expected
-            ), "UA: {0}\n expected<{1} {2} {3}> != actual<{4} {5} {6}>".format(
-                user_agent_string,
-                expected["family"],
-                expected["brand"],
-                expected["model"],
-                result["family"],
-                result["brand"],
-                result["model"],
+            assert result == expected, (
+                "UA: {0}\n expected<{1} {2} {3}> != actual<{4} {5} {6}>".format(
+                    user_agent_string,
+                    expected["family"],
+                    expected["brand"],
+                    expected["model"],
+                    result["family"],
+                    result["brand"],
+                    result["model"],
+                )
             )
 
 


### PR DESCRIPTION
I assume ruff's updated a few things since last time it was run, as it now fails