### PR TITLE
Fix memoisation of lazy parser & bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ua-parser"
 description = "Python port of Browserscope's user agent parser"
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.rst"
 requires-python = ">=3.9"
 dependencies = ["ua-parser-builtins"]

--- a/tests/test_convenience_parser.py
+++ b/tests/test_convenience_parser.py
@@ -1,4 +1,21 @@
+import ua_parser
 from ua_parser import Domain, Parser, PartialResult, Result
+
+
+def test_parser_memoized() -> None:
+    """The global parser should be lazily instantiated but memoized"""
+    # ensure there is no global parser
+    vars(ua_parser).pop("parser", None)
+
+    p1 = ua_parser.parser
+    p2 = ua_parser.parser
+
+    assert p1 is p2
+
+    # force the creation of a clean parser
+    del ua_parser.parser
+    p3 = ua_parser.parser
+    assert p3 is not p1
 
 
 def resolver(s: str, d: Domain) -> PartialResult:


### PR DESCRIPTION
Reported by @Rafiot: the lazy parser is not memoised, this has limited effect on the basic / pure Python parser as its initialisation is trivial, but it *significantly* impact the re2 and regex parsers as they need to process regexes into a filter tree.

The memoization was mistakenly removed in #230: while refactoring initialisation I removed the setting of the `parser` global.

- add a test to ensure the parser is correctly memoized, not re-instantiated every time
- reinstate setting the global
- add a mutex on `__getattr__`, it should only be used on first access and avoids two threads creating an expensive parser at the same time (which is a waste of CPU)

Fixes #253