### PR TITLE
Force running the latest version of zizmor

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Run zizmor
-        run: uvx zizmor --format sarif . > results.sarif 
+        run: uvx zizmor@latest --format sarif . > results.sarif 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 


### PR DESCRIPTION
Apparently when restoring the uv cache we might end up running an old release of zizmor, which means we don't get the latest checks.

That does avoid getting new failures in a random PR, but it's an annoyance wrt keeping the project progressing.