### PR TITLE
Fix scheduled release action for builtins

### DIFF
--- a/.github/workflows/release-builtins.yml
+++ b/.github/workflows/release-builtins.yml
@@ -1,6 +1,6 @@
 name: Publish ua-parser builtins
 
-run-name: Publish ${{ inputs.tag || 'master' }} to ${{ inputs.environment || 'dummy' }}
+run-name: Publish ${{ inputs.tag || 'master' }} to ${{ inputs.environment || 'pypy (scheduled)' }}
 
 on:
   schedule:

--- a/.github/workflows/release-builtins.yml
+++ b/.github/workflows/release-builtins.yml
@@ -28,7 +28,7 @@ jobs:
         persist-credentials: false
     - name: update core
       env:
-        TAG: ${{ inputs.tag || 'master '}}
+        TAG: ${{ inputs.tag || 'origin/master '}}
       # needs to detach because we can update to a tag
       run: git -C uap-core switch --detach "$TAG"
     - name: Set up Python

--- a/.github/workflows/release-builtins.yml
+++ b/.github/workflows/release-builtins.yml
@@ -11,9 +11,11 @@ on:
       tag:
         description: "uap-core ref to release"
         type: string
+        required: true
       environment:
         description: "environment to release for (testpypy or pypy)"
         type: environment
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
The workflow didn't work because it falls back to the ref `"master"` which the checkout does not understand. Furthermore because there is no explicit environment in the scheduled case the job description says it's deploying to "dummy" which is not true and also not really convenient.

It would be better if we could set inputs for other trigger events than `workflow_dispatch` (and I assume `workflow_call` or whatever it's called), but apparently not.