### PR TITLE
Fix builtins release checkout again

### DIFF
--- a/.github/workflows/release-builtins.yml
+++ b/.github/workflows/release-builtins.yml
@@ -11,7 +11,6 @@ on:
       tag:
         description: "uap-core ref to release"
         type: string
-        required: true
       environment:
         description: "environment to release for (testpypy or pypy)"
         type: environment
@@ -30,7 +29,7 @@ jobs:
         persist-credentials: false
     - name: update core
       env:
-        TAG: ${{ inputs.tag || 'origin/master '}}
+        TAG: ${{ inputs.tag || 'origin/master' }}
       # needs to detach because we can update to a tag
       run: git -C uap-core switch --detach "$TAG"
     - name: Set up Python


### PR DESCRIPTION
Apparently it's still not working when scheduled (https://github.com/ua-parser/uap-python/actions/runs/13608604862) even though it works fine when triggered (https://github.com/ua-parser/uap-python/actions/runs/13636193948). The logs are the exact same until the switch fails.