### PR TITLE
Update classifiers and version bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "pypy-3.10"
-          # - "pypy-3.11"
+          - "pypy-3.11"
           - "graalpy-24"
         include:
           - source: sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,10 @@ classifiers = [
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        # no graalpy classifier yet (pypa/trove-classifiers#188)
-        # "Programming Language :: Python :: Implementation :: GraalPy",
+        "Programming Language :: Python :: Implementation :: GraalPy",
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 min_version = 4.0
-env_list = py3{9,10,11,12}
-           pypy310
+env_list = py3{9,10,11,12,13}
+           pypy{310,311}
            graalpy
            flake8, black, typecheck
 labels =
-    test = py3{9,10,11,12},pypy310,graalpy
-    cpy = py3{9,10,11,12}
-    pypy = pypy3.10
-    graal = graalpy-24
+    test = py3{9,10,11,12,13},pypy{310,311},graalpy
+    cpy = py3{9,10,11,12,13}
+    pypy = pypy{310,311}
     check = flake8, black, typecheck
 
 [testenv]
@@ -21,16 +20,16 @@ wheel_build_env = .pkg
 deps =
      pytest
      pyyaml
-     google-re2
      ua-parser-rs
      ./ua-parser-builtins
 commands =
     pytest -Werror --doctest-glob="*.rst" {posargs}
 
-[testenv:{pypy310,graalpy}]
+[testenv:py3{9,10,11,12}]
 deps =
      pytest
      pyyaml
+     google-re2
      ua-parser-rs
      ./ua-parser-builtins
 

--- a/ua-parser-builtins/pyproject.toml
+++ b/ua-parser-builtins/pyproject.toml
@@ -29,9 +29,10 @@ classifiers = [
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        # "Programming Language :: Python :: Implementation :: GraalPy",
+        "Programming Language :: Python :: Implementation :: GraalPy",
 ]
 
 [tool.hatch.build.hooks.custom]


### PR DESCRIPTION
- add classifier for cpython 3.13
- add classifier for graal (now that it's been merged)
- add pypy 3.11 to tox
- re2 still hasn't published for CPython 3.13 so exclude from tox

Fixes #257, fixes #265