### PR TITLE
Disable PT030 for legacy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ classes = ["OS"]
 known-first-party = ["ua_parser"]
 combine-as-imports = true
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test_legacy.py" = ["PT030"]
+
 [tool.mypy]
 python_version = "3.9"
 files = "src,tests"


### PR DESCRIPTION
This complains that `DeprecationWarning` is too broad, and I can't care.