### PR TITLE
GitHub Actions CI: explain Zig usage in Python wheel release

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -72,6 +72,7 @@ jobs:
               match job['platform']:
                   case 'linux':
                     job['manylinux'] = 'auto'
+                    job['args'] = ' --zig'
                   case 'mussllinux':
                     job['manylinux'] = 'musllinux_1_2'
 

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -72,7 +72,7 @@ jobs:
               match job['platform']:
                   case 'linux':
                     job['manylinux'] = 'auto'
-                    job['args'] = ' --zig'
+                    job['args'] = ' --zig'  # use zig instead of docker for manylinux cross-builds (see #315)
                   case 'mussllinux':
                     job['manylinux'] = 'musllinux_1_2'
 

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -72,7 +72,6 @@ jobs:
               match job['platform']:
                   case 'linux':
                     job['manylinux'] = 'auto'
-                    job['args'] = ' --zig'
                   case 'mussllinux':
                     job['manylinux'] = 'musllinux_1_2'
 


### PR DESCRIPTION
The Zig toolchain functionality enabled here originates from a [build workflow](https://github.com/ua-parser/uap-rust/pull/3) in the `uap-rust` repository; ~~as far as I can tell, Zig is not required when building and releasing the Python wheels~~.

My understanding is that the `maturin-action` that installs the Zig dependencies [would proceed](https://github.com/PyO3/maturin-action/blob/04ac600d27cdf7a9a280dadf7147097c42b757ad/dist/index.js#L47396-L47407) even if they cannot be installed, so I don't think that their failure would block the release process here.

~~Even so, I think that software build processes should usually try to limit their build requirements to only what is necessary, so I'm offering this as a cleanup.~~

**Update**: Zig is used during the relevant GitHub Actions workflow to cross-build `manylinux` wheels; this PR has been repurposed to add an explanatory comment, instead of removing the flag to enable Zig as initial suggested.

Resolves #312.